### PR TITLE
Clean up Tor control command API

### DIFF
--- a/src/tor/AuthenticateCommand.h
+++ b/src/tor/AuthenticateCommand.h
@@ -40,15 +40,22 @@ namespace Tor
 
 class AuthenticateCommand : public TorControlCommand
 {
-public:
-    QByteArray statusMessage;
+    Q_OBJECT
 
+public:
     AuthenticateCommand();
 
     QByteArray build(const QByteArray &data = QByteArray());
 
+    bool isSuccessful() const { return statusCode() == 250; }
+    QString errorMessage() const { return m_statusMessage; }
+
 protected:
-    virtual void handleReply(int code, QByteArray &data, bool end);
+    virtual void onReply(int statusCode, const QByteArray &data);
+    virtual void onFinished(int statusCode);
+
+private:
+    QString m_statusMessage;
 };
 
 }

--- a/src/tor/GetConfCommand.h
+++ b/src/tor/GetConfCommand.h
@@ -48,7 +48,13 @@ class GetConfCommand : public TorControlCommand
     Q_PROPERTY(QVariantMap results READ results CONSTANT)
 
 public:
-    GetConfCommand(const char *type = "GETCONF");
+    enum Type {
+        GetConf,
+        GetInfo
+    };
+    const Type type;
+
+    GetConfCommand(Type type);
 
     QByteArray build(const QByteArray &key);
     QByteArray build(const QList<QByteArray> &keys);
@@ -57,7 +63,7 @@ public:
     QVariant get(const QByteArray &key) const;
 
 protected:
-    virtual void handleReply(int code, QByteArray &data, bool end);
+    virtual void onReply(int statusCode, const QByteArray &data);
 
 private:
     QVariantMap m_results;

--- a/src/tor/ProtocolInfoCommand.cpp
+++ b/src/tor/ProtocolInfoCommand.cpp
@@ -38,7 +38,7 @@
 using namespace Tor;
 
 ProtocolInfoCommand::ProtocolInfoCommand(TorControl *m)
-    : TorControlCommand("PROTOCOLINFO"), manager(m)
+    : manager(m)
 {
 }
 
@@ -47,11 +47,10 @@ QByteArray ProtocolInfoCommand::build()
     return QByteArray("PROTOCOLINFO 1\r\n");
 }
 
-void ProtocolInfoCommand::handleReply(int code, QByteArray &data, bool end)
+void ProtocolInfoCommand::onReply(int statusCode, const QByteArray &data)
 {
-    Q_UNUSED(end);
-
-    if (code != 250)
+    TorControlCommand::onReply(statusCode, data);
+    if (statusCode != 250)
         return;
 
     if (data.startsWith("AUTH "))

--- a/src/tor/ProtocolInfoCommand.h
+++ b/src/tor/ProtocolInfoCommand.h
@@ -64,7 +64,7 @@ public:
     QString cookieFile() const { return m_cookieFile; }
 
 protected:
-    virtual void handleReply(int code, QByteArray &data, bool end);
+    virtual void onReply(int statusCode, const QByteArray &data);
 
 private:
     TorControl *manager;

--- a/src/tor/SetConfCommand.cpp
+++ b/src/tor/SetConfCommand.cpp
@@ -36,7 +36,7 @@
 using namespace Tor;
 
 SetConfCommand::SetConfCommand()
-    : TorControlCommand("SETCONF"), m_resetMode(false)
+    : m_resetMode(false)
 {
 }
 
@@ -88,18 +88,19 @@ QByteArray SetConfCommand::build(const QList<QPair<QByteArray, QByteArray> > &da
     return out;
 }
 
-void SetConfCommand::handleReply(int code, QByteArray &data, bool end)
+void SetConfCommand::onReply(int statusCode, const QByteArray &data)
 {
-    Q_UNUSED(code);
+    TorControlCommand::onReply(statusCode, data);
+    if (statusCode != 250)
+        m_errorMessage = QString::fromLatin1(data);
+}
 
-    if (end)
-    {
-        if (isSuccessful()) {
-            emit setConfSucceeded();
-        } else {
-            m_errorMessage = QString::fromLatin1(data);
-            emit setConfFailed(code);
-        }
-    }
+void SetConfCommand::onFinished(int statusCode)
+{
+    TorControlCommand::onFinished(statusCode);
+    if (isSuccessful())
+        emit setConfSucceeded();
+    else
+        emit setConfFailed(statusCode);
 }
 

--- a/src/tor/SetConfCommand.h
+++ b/src/tor/SetConfCommand.h
@@ -69,7 +69,8 @@ protected:
     QString m_errorMessage;
     bool m_resetMode;
 
-    virtual void handleReply(int code, QByteArray &data, bool end);
+    virtual void onReply(int statusCode, const QByteArray &data);
+    virtual void onFinished(int statusCode);
 };
 
 }

--- a/src/tor/TorControlCommand.cpp
+++ b/src/tor/TorControlCommand.cpp
@@ -31,33 +31,33 @@
  */
 
 #include "TorControlCommand.h"
+#include <QDebug>
 
 using namespace Tor;
 
-TorControlCommand::TorControlCommand(const char *kw)
-    : keyword(kw), pStatusCode(0)
+TorControlCommand::TorControlCommand()
+    : m_finalStatus(0)
 {
 }
 
-void TorControlCommand::handleReply(int code, QByteArray &data, bool end)
+void TorControlCommand::onReply(int statusCode, const QByteArray &data)
 {
-    Q_UNUSED(code);
+    emit replyLine(statusCode, data);
+}
+
+void TorControlCommand::onFinished(int statusCode)
+{
+    m_finalStatus = statusCode;
+    emit finished();
+}
+
+void TorControlCommand::onDataLine(const QByteArray &data)
+{
     Q_UNUSED(data);
-    Q_UNUSED(end);
 }
 
-void TorControlCommand::inputReply(int code, QByteArray &data, bool end)
+void TorControlCommand::onDataFinished()
 {
-    pStatusCode = code;
-    pData += data;
-    pData += "\r\n";
-    emit replyLine(code, data, end);
-    if (end)
-        emit reply(code, pData);
-
-    handleReply(code, data, end);
-
-    if (end)
-        emit finished();
+    qWarning() << "torctrl: Unexpected data response for command";
 }
 

--- a/src/tor/TorControlCommand.h
+++ b/src/tor/TorControlCommand.h
@@ -47,25 +47,22 @@ class TorControlCommand : public QObject
     friend class TorControlSocket;
 
 public:
-    const char * const keyword;
+    TorControlCommand();
 
-    TorControlCommand(const char *keyword);
-
-    int statusCode() const { return pStatusCode; }
+    int statusCode() const { return m_finalStatus; }
 
 signals:
-    void replyLine(int code, const QByteArray &data, bool lastLine);
-    void reply(int code, const QByteArray &data);
+    void replyLine(int statusCode, const QByteArray &data);
     void finished();
 
 protected:
-    virtual void handleReply(int code, QByteArray &data, bool end);
+    virtual void onReply(int statusCode, const QByteArray &data);
+    virtual void onFinished(int statusCode);
+    virtual void onDataLine(const QByteArray &data);
+    virtual void onDataFinished();
 
 private:
-    QByteArray pData;
-    int pStatusCode;
-
-    void inputReply(int code, QByteArray &data, bool end);
+    int m_finalStatus;
 };
 
 }

--- a/src/tor/TorControlSocket.h
+++ b/src/tor/TorControlSocket.h
@@ -48,23 +48,28 @@ public:
     explicit TorControlSocket(QObject *parent = 0);
     virtual ~TorControlSocket();
 
-    void registerEvent(const QByteArray &action, TorControlCommand *handler);
+    QString errorMessage() const { return m_errorMessage; }
+
+    void registerEvent(const QByteArray &event, TorControlCommand *handler);
 
     void sendCommand(const QByteArray &data) { sendCommand(0, data); }
     void sendCommand(TorControlCommand *command, const QByteArray &data);
 
 signals:
-    void commandFinished(TorControlCommand *command);
-    void controlError(const QString &message);
+    void error(const QString &message);
 
 private slots:
     void process();
-    void clearCommands();
+    void clear();
 
 private:
     QQueue<TorControlCommand*> commandQueue;
     QHash<QByteArray,TorControlCommand*> eventCommands;
-    TorControlCommand *activeEventCommand;
+    QString m_errorMessage;
+    TorControlCommand *currentCommand;
+    bool inDataReply;
+
+    void setError(const QString &message);
 };
 
 }


### PR DESCRIPTION
This was a small tangent while looking at fixing #59. The API of TorControlCommand is made less-ugly, support for multiline data replies is added, and error handling is mildly improved.
