### PR TITLE
Adding pig-config for ubuntu build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,7 +23,7 @@ yum install tor # or build your own
 ```
 #### Ubuntu 14.04 or later
 ```sh
-apt-get install build-essential libssl-dev qt5-qmake qt5-default qtbase5-dev qttools5-dev-tools qtdeclarative5-dev qtdeclarative5-controls-plugin
+apt-get install build-essential libssl-dev pkg-config qt5-qmake qt5-default qtbase5-dev qttools5-dev-tools qtdeclarative5-dev qtdeclarative5-controls-plugin
 apt-get install tor # or build your own
 ```
 #### Qt SDK


### PR DESCRIPTION
This was missing from a clean ubuntu build box - caused a "Project ERROR: libcrypto development package not found" error message
