### PR TITLE
ui: Fix new chat window opens only to the right #85

### DIFF
--- a/src/ui/qml/ContactActions.qml
+++ b/src/ui/qml/ContactActions.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Dialogs 1.1
-import QtQuick.Window 2.0
 import "ContactWindow.js" as ContactWindow
 
 Item {
@@ -10,7 +9,6 @@ Item {
     property QtObject contact
 
     function openWindow() {
-        ContactWindow.currentScreenName = Screen.name
         var window = ContactWindow.getWindow(contact)
         window.requestActivate()
     }

--- a/src/ui/qml/ContactWindow.js
+++ b/src/ui/qml/ContactWindow.js
@@ -2,7 +2,6 @@
 
 var windows = { }
 var createWindow = function() { console.log("BUG!") }
-var currentScreenName = ""
 
 function getWindow(user) {
     var id = user.uniqueID

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -69,7 +69,6 @@ ApplicationWindow {
                         if (contact.status === ContactUser.RequestPending || contact.status === ContactUser.RequestRejected) {
                             actions.openPreferences()
                         } else if (!uiSettings.data.combinedChatWindow) {
-                            ContactWindow.currentScreenName = Screen.name
                             actions.openWindow()
                         }
                     }

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.0
+import QtQuick.Window 2.0
 import im.ricochet 1.0
 import "ContactWindow.js" as ContactWindow
 
@@ -41,8 +42,8 @@ QtObject {
             re.y = mainWindow.y + (mainWindow.height / 2) - (re.height / 2)
 
             var screens = uiMain.screens
-            if (ContactWindow.currentScreenName in screens) {
-                var currentScreen = screens[ContactWindow.currentScreenName]
+            if ((mainWindow.Screen !== undefined) && (mainWindow.Screen.name in screens)) {
+                var currentScreen = screens[mainWindow.Screen.name]
                 var offsetX = currentScreen.left
                 var offsetY = currentScreen.top
                 re.x = re.x - offsetX + re.width <= currentScreen.width ? re.x : mainWindow.x - re.width - 10


### PR DESCRIPTION
On Windows a new chat window always got opened right to the main window even if this position was off the screen.

Every time the user opens a new chat window the following is happening:
- a dictionary (name -> geometry) of all screens is generated
- the screen name of the screen on which the main window is located is being fetched
- a decision based on screen geometry is made to determine where to open the new window

This code was tested on Xubuntu 14.04 (dual screen) and Windows 8.1 (single screen). Note: I couldn't reproduce the problem on linux, since the window manager would not allow to open a window off the screen. One could decide to not use this code on linux (don't know about mac) but I think a consistent behavior on all OS would be desirable.
