### PR TITLE
ui: Chat window doesn't always flash (Win) #114

### DIFF
--- a/src/ui/qml/ChatWindow.qml
+++ b/src/ui/qml/ChatWindow.qml
@@ -43,7 +43,8 @@ ApplicationWindow {
     Connections {
         target: contact
         onIncomingChatMessage: {
-            chatWindow.alert(0)
+            if (!chatPage.activeFocus)
+                chatWindow.alert(0)
         }
     }
 


### PR DESCRIPTION
On Windows a chat window in the background sometimes doesn't notify the
user about new messages. It seems, that this is caused by the alert
of an already active window. Thus checking if the window hasn't already
active focus prevents above mentioned behavior.
