### PR TITLE
Give conversation windows sense of time

### DIFF
--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -122,6 +122,7 @@ QHash<int,QByteArray> ConversationModel::roleNames() const
     roles[IsOutgoingRole] = "isOutgoing";
     roles[StatusRole] = "status";
     roles[SectionRole] = "section";
+    roles[TimespanRole] = "timespan";
     return roles;
 }
 
@@ -144,6 +145,7 @@ QVariant ConversationModel::data(const QModelIndex &index, int role) const
         case TimestampRole: return message.time;
         case IsOutgoingRole: return message.status != Received;
         case StatusRole: return message.status;
+        case TimespanRole: return index.row() < messages.size()-1 ? messages[index.row()+1].time.msecsTo(messages[index.row()].time) : -1;
 
         case SectionRole: {
             if (m_contact->status() == ContactUser::Online)

--- a/src/core/ConversationModel.h
+++ b/src/core/ConversationModel.h
@@ -18,7 +18,8 @@ public:
         TimestampRole = Qt::UserRole,
         IsOutgoingRole,
         StatusRole,
-        SectionRole
+        SectionRole,
+        TimespanRole
     };
 
     enum MessageStatus {

--- a/src/ui/qml/GeneralPreferences.qml
+++ b/src/ui/qml/GeneralPreferences.qml
@@ -18,7 +18,7 @@ ColumnLayout {
 
     CheckBox {
         text: qsTr("Open links in default browser without prompting")
-        checked: uiSettings.data.alwaysOpenBrowser
+        checked: uiSettings.data.alwaysOpenBrowser || false
         onCheckedChanged: {
             uiSettings.write("alwaysOpenBrowser", checked)
         }

--- a/src/ui/qml/GeneralPreferences.qml
+++ b/src/ui/qml/GeneralPreferences.qml
@@ -24,6 +24,14 @@ ColumnLayout {
         }
     }
 
+    CheckBox {
+        text: qsTr("Show timestamp on each chat message")
+        checked: uiSettings.data.alwaysShowTimestamps || false
+        onCheckedChanged: {
+            uiSettings.write("alwaysShowTimestamps", checked)
+        }
+    }
+
     Item {
         Layout.fillHeight: true
         Layout.fillWidth: true

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -6,6 +6,15 @@ Column {
     id: delegate
     width: parent.width
 
+    function localDateTime(date, includeDate) {
+        var str = ""
+        if (includeDate)
+            str = date.toLocaleDateString() + " "
+        //Workaround to remove timezone name, which is included on Xubuntu 14.04 but not on Windows 8.1
+        str += date.toLocaleTimeString().replace(/ [A-Z]{3,}| CT| NT| Z| ChST/g, "")
+        return str
+    }
+
     Loader {
         active: model.section === "offline"
         sourceComponent: Label {
@@ -87,7 +96,12 @@ Column {
             wrapMode: TextEdit.Wrap
             readOnly: true
             selectByMouse: true
-            text: LinkedText.parsed(model.text)
+            text: {
+                var timeStamp = ""
+                if (uiSettings.data.alwaysShowTimestamps)
+                        timeStamp = '<span style="color: #333333; font-size: 6.5pt">' + localDateTime(model.timestamp) + '</span><br />'
+                return timeStamp + LinkedText.parsed(model.text)
+            }
 
             onLinkActivated: delegate.showContextMenu(link)
 

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -75,13 +75,18 @@ Column {
 
         MouseArea {
             anchors.fill: parent
-            acceptedButtons: Qt.RightButton
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
 
-            onClicked: delegate.showContextMenu()
+            onClicked: {
+                if (mouse.button === Qt.RightButton)
+                    delegate.showContextMenu()
+            }
+            onDoubleClicked: textField.showTimeStamp = !textField.showTimeStamp
         }
 
         TextEdit {
             id: textField
+            property bool showTimeStamp: false
             width: Math.min(implicitWidth, background.__maxWidth)
             height: contentHeight
             x: Math.round((parent.width - width) / 2)
@@ -98,7 +103,7 @@ Column {
             selectByMouse: true
             text: {
                 var timeStamp = ""
-                if (uiSettings.data.alwaysShowTimestamps)
+                if ((uiSettings.data.alwaysShowTimestamps) || (textField.showTimeStamp))
                         timeStamp = '<span style="color: #333333; font-size: 6.5pt">' + localDateTime(model.timestamp) + '</span><br />'
                 return timeStamp + LinkedText.parsed(model.text)
             }

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -16,10 +16,16 @@ Column {
     }
 
     Loader {
-        active: model.section === "offline"
+        active: model.section === "offline" || ((model.timespan === -1 || model.timespan > 3600000) && (!uiSettings.data.alwaysShowTimestamps))
         sourceComponent: Label {
             //: %1 nickname
-            text: qsTr("%1 is offline").arg(contact !== null ? contact.nickname : "")
+            text: {
+                if (model.section === "offline") {
+                    qsTr("%1 is offline").arg(contact !== null ? contact.nickname : "")
+                } else {
+                    localDateTime(model.timestamp, true)
+                }
+            }
             width: background.parent.width
             elide: Text.ElideRight
             horizontalAlignment: Qt.AlignHCenter


### PR DESCRIPTION
This is a feature I missed, so here is my approach to include timestamps in chat windows. I have to admit that I like timestamps on every message so I shamelessly implemented that first (it was the easiest, too). But it is disabled by default, it can be activated in Preferences -> General. The default behaviour is:
 - Add a date/time separator whenever a new conversation is started or one hour has passed since the last exchange of messages. This uses the separator which is shown when the chat partner is offline. When a new conversation is started and the partner is offline this text is still shown.
 - I liked the idead of @obvio171 so one can double click a bubble to see the timestamp of the message. This might be a little tricky, because you have to click the bubble not the text in it. This is because if you include the MouseArea on top of the text the text can't be selected anymore (while writing these lines I'm thinking a tool tip on mouse over might be a better solution).

Here are a few examples:

Default behaviour on Xubuntu with locale set to en_US. Bubble 2 got double clicked
![screenshot - 10222014 - 01 01 53 am](https://cloud.githubusercontent.com/assets/6523647/4732752/3be04daa-59c0-11e4-88e9-10e60f5864b8.png)

Default behaviour on Xubuntu with locale set to de_DE. Bubble 2 got double clicked, partner went offline before sending message 2.
![screenshot - 22 10 2014 - 10 03 28](https://cloud.githubusercontent.com/assets/6523647/4732914/15af1830-59c2-11e4-9ecf-3b07e866f766.png)

Default behaviour on Windows with threshold set to a few seconds.
![unbenannt2](https://cloud.githubusercontent.com/assets/6523647/4732980/047dcec0-59c3-11e4-8401-26cfbeb3df18.png)

Same window with 'show timestamp on every chat message' activated
![unbenannt](https://cloud.githubusercontent.com/assets/6523647/4732981/04866652-59c3-11e4-9737-ca64f6ac90a0.png)

What do you think?