### PR TITLE
Add methods to sign a SHA256 digest directly and improve tests

### DIFF
--- a/src/protocol/ContactRequestServer.cpp
+++ b/src/protocol/ContactRequestServer.cpp
@@ -209,7 +209,7 @@ void ContactRequestServer::handleRequest(const QByteArray &data)
     }
 
     /* Verify the signature */
-    if (!key.verifySignature(data.mid(2, signaturePos - 2), signature)) {
+    if (!key.verifyData(data.mid(2, signaturePos - 2), signature)) {
         qDebug() << "Incoming contact request has an invalid signature; rejecting";
         sendResponse(0x81);
         return;

--- a/src/utils/CryptoKey.h
+++ b/src/utils/CryptoKey.h
@@ -60,9 +60,15 @@ public:
     QByteArray encodedPublicKey() const;
     QString torServiceID() const;
 
-    /* Raw signatures; no digest */
+    // Calculate and sign SHA-256 digest of data using this key and PKCS #1 v2.0 padding
     QByteArray signData(const QByteArray &data) const;
-    bool verifySignature(const QByteArray &data, QByteArray signature) const;
+    // Verify a signature as per signData
+    bool verifyData(const QByteArray &data, QByteArray signature) const;
+
+    // Sign the input SHA-256 digest using this key and PKCS #1 v2.0 padding
+    QByteArray signSHA256(const QByteArray &digest) const;
+    // Verify a signature as per signSHA256
+    bool verifySHA256(const QByteArray &digest, QByteArray signature) const;
 
 private:
     struct Data : public QSharedData


### PR DESCRIPTION
These new methods will become useful later, but more importantly this corrects the documentation that claimed `signData` did not use a digest. The tests are also improved, including verifying against a precomputed known-good signature.
