### PR TITLE
Fix network setup getting stuck when tor fails

### DIFF
--- a/src/ui/qml/NetworkSetupWizard.qml
+++ b/src/ui/qml/NetworkSetupWizard.qml
@@ -80,7 +80,9 @@ ApplicationWindow {
 
         onHasErrorChanged: {
             if (hasError) {
-                visibleItem.visible = false
+                if (visibleItem)
+                    visibleItem.visible = false
+                pageLoader.visible = false
                 statusPage.visible = true
                 visibleItem = statusPage
             }
@@ -133,6 +135,8 @@ ApplicationWindow {
     }
 
     Behavior on height {
+        // This window animation causes bad graphical behavior on Windows with 5.4.1
+        enabled: Qt.platform.os !== "windows"
         SmoothedAnimation {
             easing.type: Easing.InOutQuad
             velocity: 1500

--- a/src/ui/qml/StartupStatusPage.qml
+++ b/src/ui/qml/StartupStatusPage.qml
@@ -34,7 +34,7 @@ Column {
     TorLogDisplay {
         id: logDisplay
         width: parent.width
-        height: 300
+        height: text.length > 0 ? 300 : 0
     }
 
     RowLayout {


### PR DESCRIPTION
If tor failed before the first page was visible on screen, it would
appear to be stuck on the first setup screen, rather than displaying the
error (often that the executable is missing).

Also disabled the window height animation on Windows, as it causes some
graphical glitches.