### PR TITLE
Connection and user handling for new protocol

### DIFF
--- a/ricochet.pro
+++ b/ricochet.pro
@@ -122,30 +122,19 @@ SOURCES += src/main.cpp \
     src/utils/StringUtil.cpp \
     src/core/ContactsManager.cpp \
     src/core/ContactUser.cpp \
-    src/protocol/ProtocolCommand.cpp \
-    src/protocol/PingCommand.cpp \
-    src/protocol/IncomingSocket.cpp \
-    src/protocol/ChatMessageCommand.cpp \
-    src/protocol/CommandHandler.cpp \
-    src/protocol/CommandDataParser.cpp \
     src/tor/GetConfCommand.cpp \
     src/tor/HiddenService.cpp \
-    src/protocol/ProtocolSocket.cpp \
     src/utils/CryptoKey.cpp \
     src/utils/SecureRNG.cpp \
-    src/protocol/ContactRequestClient.cpp \
-    src/protocol/ContactRequestServer.cpp \
     src/core/OutgoingContactRequest.cpp \
     src/core/IncomingRequestManager.cpp \
     src/core/ContactIDValidator.cpp \
-    src/protocol/GetSecretCommand.cpp \
     src/core/UserIdentity.cpp \
     src/core/IdentityManager.cpp \
     src/core/ConversationModel.cpp \
     src/tor/TorProcess.cpp \
     src/tor/TorManager.cpp \
     src/tor/TorSocket.cpp \
-    src/protocol/OutgoingContactSocket.cpp \
     src/ui/LinkedText.cpp \
     src/utils/Settings.cpp \
     src/utils/PendingOperation.cpp
@@ -161,23 +150,13 @@ HEADERS += src/ui/MainWindow.h \
     src/utils/StringUtil.h \
     src/core/ContactsManager.h \
     src/core/ContactUser.h \
-    src/protocol/ProtocolCommand.h \
-    src/protocol/PingCommand.h \
-    src/protocol/IncomingSocket.h \
-    src/protocol/ChatMessageCommand.h \
-    src/protocol/CommandHandler.h \
-    src/protocol/CommandDataParser.h \
     src/tor/GetConfCommand.h \
     src/tor/HiddenService.h \
-    src/protocol/ProtocolSocket.h \
     src/utils/CryptoKey.h \
     src/utils/SecureRNG.h \
-    src/protocol/ContactRequestClient.h \
-    src/protocol/ContactRequestServer.h \
     src/core/OutgoingContactRequest.h \
     src/core/IncomingRequestManager.h \
     src/core/ContactIDValidator.h \
-    src/protocol/GetSecretCommand.h \
     src/core/UserIdentity.h \
     src/core/IdentityManager.h \
     src/core/ConversationModel.h \
@@ -185,7 +164,6 @@ HEADERS += src/ui/MainWindow.h \
     src/tor/TorProcess_p.h \
     src/tor/TorManager.h \
     src/tor/TorSocket.h \
-    src/protocol/OutgoingContactSocket.h \
     src/ui/LinkedText.h \
     src/utils/Settings.h \
     src/utils/PendingOperation.h
@@ -208,6 +186,30 @@ contains(DEFINES,PROTOCOL_NEW) {
     include(protobuf.pri)
     PROTOS += src/protocol/ControlChannel.proto \
         src/protocol/AuthHiddenService.proto
+} else {
+    SOURCES += src/protocol/ProtocolCommand.cpp \
+        src/protocol/PingCommand.cpp \
+        src/protocol/IncomingSocket.cpp \
+        src/protocol/ChatMessageCommand.cpp \
+        src/protocol/CommandHandler.cpp \
+        src/protocol/CommandDataParser.cpp \
+        src/protocol/ProtocolSocket.cpp \
+        src/protocol/ContactRequestClient.cpp \
+        src/protocol/ContactRequestServer.cpp \
+        src/protocol/GetSecretCommand.cpp \
+        src/protocol/OutgoingContactSocket.cpp
+
+    HEADERS += src/protocol/ProtocolCommand.h \
+        src/protocol/PingCommand.h \
+        src/protocol/IncomingSocket.h \
+        src/protocol/ChatMessageCommand.h \
+        src/protocol/CommandHandler.h \
+        src/protocol/CommandDataParser.h \
+        src/protocol/ProtocolSocket.h \
+        src/protocol/ContactRequestClient.h \
+        src/protocol/ContactRequestServer.h \
+        src/protocol/GetSecretCommand.h \
+        src/protocol/OutgoingContactSocket.h
 }
 
 # QML

--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -34,23 +34,33 @@
 #include "UserIdentity.h"
 #include "ContactsManager.h"
 #include "utils/SecureRNG.h"
-#include "protocol/GetSecretCommand.h"
-#include "protocol/ChatMessageCommand.h"
-#include "protocol/OutgoingContactSocket.h"
-#include "protocol/ProtocolConstants.h"
 #include "core/ContactIDValidator.h"
 #include "core/OutgoingContactRequest.h"
 #include "core/ConversationModel.h"
+#include "tor/HiddenService.h"
 #include <QtDebug>
 #include <QDateTime>
+
+#ifdef PROTOCOL_NEW
+#include "protocol/OutboundConnector.h"
+#include "utils/Useful.h"
+#else
+#include "protocol/GetSecretCommand.h"
+#include "protocol/ChatMessageCommand.h"
+#include "protocol/ProtocolConstants.h"
+#include "protocol/OutgoingContactSocket.h"
+#endif
 
 ContactUser::ContactUser(UserIdentity *ident, int id, QObject *parent)
     : QObject(parent)
     , identity(ident)
     , uniqueID(id)
+#ifdef PROTOCOL_NEW
+    , m_connection(0)
+#endif
+    , m_outgoingSocket(0)
     , m_lastReceivedChatID(0)
     , m_contactRequest(0)
-    , m_outgoingSocket(0)
     , m_settings(0)
     , m_conversation(0)
 {
@@ -62,9 +72,11 @@ ContactUser::ContactUser(UserIdentity *ident, int id, QObject *parent)
     m_conversation = new ConversationModel(this);
     m_conversation->setContact(this);
 
+#ifndef PROTOCOL_NEW
     m_conn = new ProtocolSocket(this);
     connect(m_conn, SIGNAL(connected()), this, SLOT(onConnected()));
     connect(m_conn, SIGNAL(disconnected()), this, SLOT(onDisconnected()));
+#endif
 
     loadContactRequest();
     updateStatus();
@@ -88,8 +100,10 @@ ContactUser *ContactUser::addNewContact(UserIdentity *identity, int id)
     ContactUser *user = new ContactUser(identity, id);
     user->settings()->write("whenCreated", QDateTime::currentDateTime());
 
+#ifndef PROTOCOL_NEW
     /* Generate the local secret and set it */
     user->settings()->write("localSecret", Base64Encode(SecureRNG::random(16)));
+#endif
 
     return user;
 }
@@ -106,7 +120,11 @@ void ContactUser::updateStatus()
             newStatus = RequestPending;
         }
     } else {
+#ifdef PROTOCOL_NEW
+        newStatus = m_connection && m_connection->isConnected() ? Online : Offline;
+#else
         newStatus = m_conn->isConnected() ? Online : Offline;
+#endif
     }
 
     if (newStatus == m_status)
@@ -115,8 +133,12 @@ void ContactUser::updateStatus()
     m_status = newStatus;
     emit statusChanged();
 
+#ifdef PROTOCOL_NEW
+    updateOutgoingSocket();
+#else
     if (m_status == Offline)
-        setupOutgoingSocket();
+        updateOutgoingSocket();
+#endif
 }
 
 void ContactUser::onSettingsModified(const QString &key, const QJsonValue &value)
@@ -126,17 +148,36 @@ void ContactUser::onSettingsModified(const QString &key, const QJsonValue &value
         emit nicknameChanged();
 }
 
-void ContactUser::setupOutgoingSocket()
+void ContactUser::updateOutgoingSocket()
 {
     if (m_status != Offline)
         return;
 
-    QByteArray secret = m_settings->read<Base64Encode>("remoteSecret");
-    if (secret.isEmpty() || hostname().isEmpty() || !port())
-        return;
-
     // Refuse to make outgoing connections to the local hostname
     if (hostname() == identity->hostname())
+        return;
+
+#ifdef PROTOCOL_NEW
+    if (m_outgoingSocket && m_outgoingSocket->status() == Protocol::OutboundConnector::Ready) {
+        BUG() << "Called updateOutgoingSocket with an existing socket in Ready. This should've been deleted.";
+        m_outgoingSocket->disconnect(this);
+        m_outgoingSocket->deleteLater();
+        m_outgoingSocket = 0;
+    }
+
+    if (!m_outgoingSocket) {
+        m_outgoingSocket = new Protocol::OutboundConnector(this);
+        m_outgoingSocket->setAuthPrivateKey(identity->hiddenService()->cryptoKey());
+        connect(m_outgoingSocket, &Protocol::OutboundConnector::ready, this,
+            [this]() {
+                assignConnection(m_outgoingSocket->takeConnection(this));
+            }
+        );
+    }
+
+#else
+    QByteArray secret = m_settings->read<Base64Encode>("remoteSecret");
+    if (secret.isEmpty() || hostname().isEmpty() || !port())
         return;
 
     if (!m_outgoingSocket) {
@@ -147,6 +188,8 @@ void ContactUser::setupOutgoingSocket()
     }
 
     m_outgoingSocket->setAuthentication(Protocol::PurposePrimary, secret);
+#endif
+
     m_outgoingSocket->connectToHost(hostname(), port());
 }
 
@@ -154,8 +197,7 @@ void ContactUser::onConnected()
 {
     m_settings->write("lastConnected", QDateTime::currentDateTime());
 
-    if (m_contactRequest)
-    {
+    if (m_contactRequest) {
         qDebug() << "Implicitly accepting outgoing contact request for" << uniqueID << "from primary connection";
 
         m_contactRequest->accept();
@@ -163,12 +205,14 @@ void ContactUser::onConnected()
         Q_ASSERT(status() != RequestPending);
     }
 
+#ifndef PROTOCOL_NEW
     if (m_settings->read("remoteSecret") == QJsonValue::Undefined)
     {
         qDebug() << "Requesting remote secret from user" << uniqueID;
         GetSecretCommand *command = new GetSecretCommand(this);
         command->send(conn());
     }
+#endif
 
     updateStatus();
     emit connected();
@@ -221,7 +265,7 @@ void ContactUser::setHostname(const QString &hostname)
         fh.append(QLatin1String(".onion"));
 
     m_settings->write("hostname", fh);
-    setupOutgoingSocket();
+    updateOutgoingSocket();
 }
 
 void ContactUser::deleteContact()
@@ -231,8 +275,7 @@ void ContactUser::deleteContact()
 
     qDebug() << "Deleting contact" << uniqueID;
 
-    if (m_contactRequest)
-    {
+    if (m_contactRequest) {
         qDebug() << "Cancelling request associated with contact to be deleted";
         m_contactRequest->cancel();
         m_contactRequest->deleteLater();
@@ -240,9 +283,11 @@ void ContactUser::deleteContact()
 
     emit contactDeleted(this);
 
+#ifndef PROTOCOL_NEW
     m_conn->disconnect();
     delete m_conn;
     m_conn = 0;
+#endif
 
     m_settings->undefine();
     deleteLater();
@@ -257,6 +302,7 @@ void ContactUser::requestRemoved()
     }
 }
 
+#ifndef PROTOCOL_NEW
 static bool isOutgoing(QTcpSocket *socket)
 {
     return socket->inherits("Tor::TorSocket");
@@ -277,7 +323,8 @@ void ContactUser::incomingProtocolSocket(QTcpSocket *socket)
      *   onion-formatted hostname is considered less by a strcmp function.
      */
 
-    if (!isOutgoing(socket) && m_outgoingSocket && !m_outgoingSocket->isAuthenticationPending()) {
+    if (!isOutgoing(socket) && m_outgoingSocket && !m_outgoingSocket->isAuthenticationPending())
+    {
         // Abort connection attempt and use this socket
         m_outgoingSocket->disconnect();
         m_outgoingSocket->deleteLater();
@@ -307,4 +354,122 @@ void ContactUser::incomingProtocolSocket(QTcpSocket *socket)
         m_outgoingSocket = 0;
     }
 }
+#else
+void ContactUser::assignConnection(Protocol::Connection *connection)
+{
+    if (connection->parent() == this) {
+        BUG() << "Connection is already owned by this ContactUser";
+        return;
+    }
 
+    if (qobject_cast<ContactUser*>(connection->parent())) {
+        BUG() << "Connection is already owned by another ContactUser";
+        connection->close();
+        return;
+    }
+
+    connection->setParent(this);
+    bool isOutbound = connection->direction() == Protocol::Connection::ClientSide;
+
+    if (!connection->isConnected()) {
+        BUG() << "Connection assigned to contact but isn't connected; discarding";
+        connection->close();
+        connection->deleteLater();
+        return;
+    }
+
+    if (!connection->hasAuthenticatedAs(Protocol::Connection::HiddenServiceAuth, hostname())) {
+        BUG() << "Connection assigned to contact without matching authentication";
+        connection->close();
+        connection->deleteLater();
+        return;
+    }
+
+    /* To resolve a race if two contacts try to connect at the same time:
+     *
+     * If an inbound connection arrives and there is no outbound connection,
+     * or the outbound connection hasn't sent authentication yet, use inbound.
+     */
+    if (!isOutbound && m_outgoingSocket && m_outgoingSocket->status() < Protocol::OutboundConnector::Authenticating) {
+        qDebug() << "Aborting outbound connection attempt because we got an inbound connection instead";
+        m_outgoingSocket->abort();
+        // XXX what do we do with this
+        m_outgoingSocket->deleteLater();
+        m_outgoingSocket = 0;
+    }
+
+    /* If the existing connection is in the same direction as the new one,
+     * always use the new one.
+     */
+    if (m_connection && connection->direction() == m_connection->direction()) {
+        qDebug() << "Replacing existing connection with contact because the new one goes the same direction";
+        // XXX things
+        m_connection = 0;
+    }
+
+    /* If the existing connection is more than 30 seconds old, measured from
+     * when it was successfully established, it's replaced with the new one.
+     */
+    if (m_connection && m_connection->age() > 30) {
+        qDebug() << "Replacing existing connection with contact because it's more than 30 seconds old";
+        // XXX do things to get rid of the existing connection
+        m_connection = 0;
+    }
+
+    /* Otherwise, close the connection for which the server's onion-formatted
+     * hostname compares less with a strcmp function
+     */
+    bool preferOutbound = QString::compare(hostname(), identity->hostname()) < 0;
+    if (m_connection) {
+        if (isOutbound == preferOutbound) {
+            // New connection wins
+            // XXX do things to get rid of existing connection
+            m_connection = 0;
+        } else {
+            // Old connection wins
+            qDebug() << "Closing new connection with contact because the old connection won comparison";
+            connection->close();
+            connection->deleteLater();
+            return;
+        }
+    }
+
+    if (!isOutbound && m_outgoingSocket) {
+        if (preferOutbound) {
+            // Outbound attempt wins
+            qDebug() << "Closing new connection with contact because the pending outbound connection won comparison";
+            connection->close();
+            connection->deleteLater();
+            return;
+        } else {
+            // Inbound connection wins
+            qDebug() << "Aborting outbound conncetion attempt because an inbound connection won comparison";
+            m_outgoingSocket->abort();
+            // XXX what to do with this
+            m_outgoingSocket->deleteLater();
+            m_outgoingSocket = 0;
+        }
+    }
+
+    if (m_connection) {
+        BUG() << "After resolving connection races, ContactUser still has two connections";
+        connection->close();
+        connection->deleteLater();
+        return;
+    }
+
+    qDebug() << "Assigned" << (isOutbound ? "outbound" : "inbound") << "connection to contact" << uniqueID;
+    if (!connection->setPurpose(Protocol::Connection::Purpose::KnownContact)) {
+        qWarning() << "BUG: Failed setting connection purpose";
+        connection->close();
+        connection->deleteLater();
+        return;
+    }
+
+    m_connection = connection;
+    connect(m_connection, &Protocol::Connection::closed, this, &ContactUser::onDisconnected);
+    onConnected();
+
+    // XXX check what happens to m_outgoingSocket after it completes
+}
+#endif

--- a/src/core/ContactUser.h
+++ b/src/core/ContactUser.h
@@ -190,6 +190,10 @@ private:
 
     void loadContactRequest();
     void updateOutgoingSocket();
+
+#ifdef PROTOCOL_NEW
+    void clearConnection();
+#endif
 };
 
 Q_DECLARE_METATYPE(ContactUser*)

--- a/src/core/ContactUser.h
+++ b/src/core/ContactUser.h
@@ -38,14 +38,23 @@
 #include <QMetaType>
 #include <QVariant>
 #include "utils/Settings.h"
-#include "protocol/ProtocolSocket.h"
 
 class UserIdentity;
+class OutgoingContactRequest;
+class ConversationModel;
+
+#ifdef PROTOCOL_NEW
+namespace Protocol
+{
+    class OutboundConnector;
+    class Connection;
+}
+#else
+#include "protocol/ProtocolSocket.h"
+class OutgoingContactSocket;
 struct ChatMessageData;
 class ChatMessageCommand;
-class OutgoingContactRequest;
-class OutgoingContactSocket;
-class ConversationModel;
+#endif
 
 /* Represents a user on the contact list.
  * All persistent uses of a ContactUser instance must either connect to the
@@ -68,8 +77,10 @@ class ContactUser : public QObject
     Q_PROPERTY(ConversationModel *conversation READ conversation CONSTANT)
 
     friend class ContactsManager;
-    friend class ChatMessageCommand;
     friend class OutgoingContactRequest;
+#ifndef PROTOCOL_NEW
+    friend class ChatMessageCommand;
+#endif
 
 public:
     enum Status
@@ -85,7 +96,11 @@ public:
 
     explicit ContactUser(UserIdentity *identity, int uniqueID, QObject *parent = 0);
 
+#ifdef PROTOCOL_NEW
+    Protocol::Connection *connection() { return m_connection; }
+#else
     ProtocolSocket *conn() const { return m_conn; }
+#endif
     bool isConnected() const { return status() == Online; }
 
     OutgoingContactRequest *contactRequest() { return m_contactRequest; }
@@ -108,12 +123,30 @@ public:
     Q_INVOKABLE void deleteContact();
 
 public slots:
+#ifdef PROTOCOL_NEW
+    /* Assign a connection to this user
+     *
+     * The connection must be connected, and the peer must be authenticated and
+     * must match this user. ContactUser will assume ownership of the connection,
+     * and it will be closed and deleted when it's no longer used.
+     *
+     * It is valid to pass an incoming or outgoing connection. If there is already
+     * a connection, protocol-specific rules are applied and the new connection
+     * may be closed to favor the older one.
+     *
+     * If the existing connection is replaced, that is equivalent to disconnecting
+     * and reconnectng immediately - any ongoing operations will fail and need to
+     * be retried at a higher level.
+     */
+    void assignConnection(Protocol::Connection *connection);
+#else
+    void incomingProtocolSocket(QTcpSocket *socket);
+#endif
+
     void setNickname(const QString &nickname);
     void setHostname(const QString &hostname);
 
     void updateStatus();
-
-    void incomingProtocolSocket(QTcpSocket *socket);
 
 signals:
     void statusChanged();
@@ -123,10 +156,12 @@ signals:
     void nicknameChanged();
     void contactDeleted(ContactUser *user);
 
+#ifndef PROTOCOL_NEW
     /* Hack to allow creating models/windows/etc to handle other signals before they're
      * emitted; primarily, to allow UI to create models to handle incomingChatMessage */
     void prepareInteractiveHandler();
     void incomingChatMessage(const ChatMessageData &message);
+#endif
 
 private slots:
     void onConnected();
@@ -135,11 +170,18 @@ private slots:
     void onSettingsModified(const QString &key, const QJsonValue &value);
 
 private:
+#ifdef PROTOCOL_NEW
+    // XXX be paranoid about tracking deletion of m_connection
+    Protocol::Connection *m_connection;
+    Protocol::OutboundConnector *m_outgoingSocket;
+#else
     ProtocolSocket *m_conn;
+    OutgoingContactSocket *m_outgoingSocket;
+#endif
+
     Status m_status;
     quint16 m_lastReceivedChatID;
     OutgoingContactRequest *m_contactRequest;
-    OutgoingContactSocket *m_outgoingSocket;
     SettingsObject *m_settings;
     ConversationModel *m_conversation;
 
@@ -147,7 +189,7 @@ private:
     static ContactUser *addNewContact(UserIdentity *identity, int id);
 
     void loadContactRequest();
-    void setupOutgoingSocket();
+    void updateOutgoingSocket();
 };
 
 Q_DECLARE_METATYPE(ContactUser*)

--- a/src/core/ContactsManager.cpp
+++ b/src/core/ContactsManager.cpp
@@ -89,8 +89,10 @@ ContactUser *ContactsManager::addContact(const QString &nickname)
 void ContactsManager::connectSignals(ContactUser *user)
 {
     connect(user, SIGNAL(contactDeleted(ContactUser*)), SLOT(contactDeleted(ContactUser*)));
-    connect(user, SIGNAL(prepareInteractiveHandler()), SLOT(onPrepareInteractiveHandler()));
     connect(user->conversation(), &ConversationModel::unreadCountChanged, this, &ContactsManager::onUnreadCountChanged);
+
+#ifndef PROTOCOL_NEW
+    connect(user, SIGNAL(prepareInteractiveHandler()), SLOT(onPrepareInteractiveHandler()));
 }
 
 void ContactsManager::onPrepareInteractiveHandler()
@@ -98,6 +100,7 @@ void ContactsManager::onPrepareInteractiveHandler()
     ContactUser *user = qobject_cast<ContactUser*>(sender());
     if (user)
         emit prepareInteractiveHandler(user);
+#endif
 }
 
 ContactUser *ContactsManager::createContactRequest(const QString &contactid, const QString &nickname,

--- a/src/core/ContactsManager.h
+++ b/src/core/ContactsManager.h
@@ -80,16 +80,21 @@ public:
 signals:
     void contactAdded(ContactUser *user);
     void outgoingRequestAdded(OutgoingContactRequest *request);
+#ifndef PROTOCOL_NEW
     /* Hack to allow creating models/windows/etc to handle other signals before they're
      * emitted; primarily, to allow UI to create models to handle incomingChatMessage */
     void prepareInteractiveHandler(ContactUser *user);
+#endif
 
     void unreadCountChanged(ContactUser *user, int unreadCount);
 
 private slots:
     void contactDeleted(ContactUser *user);
-    void onPrepareInteractiveHandler();
     void onUnreadCountChanged();
+
+#ifndef PROTOCOL_NEW
+    void onPrepareInteractiveHandler();
+#endif
 
 private:
     QList<ContactUser*> pContacts;

--- a/src/core/UserIdentity.cpp
+++ b/src/core/UserIdentity.cpp
@@ -221,6 +221,8 @@ void UserIdentity::onIncomingConnection()
                     handleIncomingAuthedConnection(conn);
             }
         );
+
+        emit incomingConnection(conn);
     }
 }
 

--- a/src/core/UserIdentity.h
+++ b/src/core/UserIdentity.h
@@ -106,6 +106,9 @@ signals:
     void contactIDChanged(); // only possible during creation
     void nicknameChanged();
     void settingsChanged(const QString &key);
+#ifdef PROTOCOL_NEW
+    void incomingConnection(Protocol::Connection *connection);
+#endif
 
 private slots:
     void onStatusChanged(int newStatus, int oldStatus);

--- a/src/core/UserIdentity.h
+++ b/src/core/UserIdentity.h
@@ -42,7 +42,16 @@ namespace Tor
     class HiddenService;
 }
 
+#ifdef PROTOCOL_NEW
+namespace Protocol
+{
+    class Connection;
+}
+
+class QTcpServer;
+#else
 class IncomingSocket;
+#endif
 
 /* UserIdentity represents the local identity offered by the user.
  *
@@ -101,13 +110,24 @@ signals:
 private slots:
     void onStatusChanged(int newStatus, int oldStatus);
     void onSettingsModified(const QString &key, const QJsonValue &value);
+#ifdef PROTOCOL_NEW
+    void onIncomingConnection();
+#endif
 
 private:
     SettingsObject *m_settings;
     Tor::HiddenService *m_hiddenService;
+#ifdef PROTOCOL_NEW
+    QTcpServer *m_incomingServer;
+#else
     IncomingSocket *incomingSocket;
+#endif
 
     static UserIdentity *createIdentity(int uniqueID, const QString &dataDirectory = QString());
+
+#ifdef PROTOCOL_NEW
+    void handleIncomingAuthedConnection(Protocol::Connection *connection);
+#endif
 };
 
 Q_DECLARE_METATYPE(UserIdentity*)

--- a/src/protocol/ContactRequestClient.cpp
+++ b/src/protocol/ContactRequestClient.cpp
@@ -247,7 +247,9 @@ bool ContactRequestClient::handleResponse()
         emit accepted();
 
         socket->disconnect(this);
+#ifndef PROTOCOL_NEW
         user->incomingProtocolSocket(socket);
+#endif
         Q_ASSERT(socket->parent() != this);
         socket = 0;
 

--- a/src/protocol/ContactRequestServer.cpp
+++ b/src/protocol/ContactRequestServer.cpp
@@ -123,7 +123,9 @@ void ContactRequestServer::sendAccept(ContactUser *user)
     qDebug() << "Contact request accepted with an active connection; sending accept and morphing to command";
 
     socket->disconnect(this);
+#ifndef PROTOCOL_NEW
     user->incomingProtocolSocket(socket);
+#endif
     Q_ASSERT(socket->parent() != this);
 
     deleteLater();

--- a/src/protocol/IncomingSocket.cpp
+++ b/src/protocol/IncomingSocket.cpp
@@ -251,7 +251,9 @@ void IncomingSocket::handleIntro(QTcpSocket *socket, uchar version)
         socket->disconnect(this);
 
         /* The protocolmanager also takes ownership */
+#ifndef PROTOCOL_NEW
         user->incomingProtocolSocket(socket);
+#endif
         Q_ASSERT(socket->parent() != this);
     }
     else if (purpose == Protocol::PurposeContactReq)

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -36,8 +36,13 @@ ApplicationWindow {
     Connections {
         target: userIdentity.contacts
         onUnreadCountChanged: {
-            if (unreadCount > 0 && !ContactWindow.windowExists(user))
-                window.alert(0)
+            if (unreadCount > 0) {
+                if (!uiSettings.data.combinedChatWindow) {
+                    var cwindow = ContactWindow.getWindow(user)
+                    cwindow.alert(0)
+                } else if (!ContactWindow.windowExists(user))
+                    window.alert(0)
+            }
         }
     }
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -77,6 +77,7 @@ QtObject {
 
         Connections {
             target: userIdentity.contacts
+            // XXX Remove with old protocol code
             onPrepareInteractiveHandler: {
                 if (!uiSettings.data.combinedChatWindow)
                     ContactWindow.getWindow(user)


### PR DESCRIPTION
First section of my [protocol branch](https://github.com/special/ricochet/compare/protocol). This implements the new protocol in ContactUser for inbound and outbound connections.

The next PR will implement chat, then contact requests, then some overall fixups and changes. All of this code is still enabled only when built with `DEFINES+=PROTOCOL_NEW`.