### PR TITLE
Alert contacts using old protocol of the need to upgrade

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -129,6 +129,38 @@ document:
 
 ## Specification
 
+### Introduction and version negotiation
+
+Immediately after establishing a connection, the client side must send an introduction message
+identifying versions of the protocol that it is able to use. The server responds with one of
+those versions, or an error indicating that no compatible version exists.
+
+This step exists to enable smoother protocol changes in the future, and for better compatibility
+with old clients.
+
+The client begins the connection by sending the following raw sequence of bytes:
+
+```
+0x49
+0x4D
+nVersions          // One byte, number of supported protocol versions
+nVersions times:
+    version        // One byte, protocol version number
+```
+
+The total size is 3 plus the number of supported versions bytes. The server side of the connection
+must respond with a single byte for the selected version number, or 0xFF if no suitable version
+is found.
+
+This document describes protocol version 1. Known versions are:
+```
+0                  The Ricochet 1.0 protocol
+1                  This document
+```
+
+If the negotiation is successful, the connection can be immediately used to begin exchanging messages
+(the packet layer, below).
+
 ### Packet layer
 
 The base layer on the connection is a trivial packet structure:

--- a/src/protocol/Connection.h
+++ b/src/protocol/Connection.h
@@ -163,6 +163,16 @@ signals:
      * or to reconnect the socket.
      */
     void closed();
+    /* Emitted once, after version negotiation has finished and the connection
+     * is ready to use. If negotiation fails, the versionNegotiationFailed
+     * signal is emitted instead, and the socket is closed.
+     */
+    void ready();
+    /* Emitted once when version negotiation has failed; meaning, there is no
+     * protocol version that both peers will accept. The socket will be closed.
+     */
+    void versionNegotiationFailed();
+
     void authenticated(AuthenticationType type, const QString &identity);
     void purposeChanged(Purpose after, Purpose before);
     /* Emitted when a new Channel instance is created, before it has opened

--- a/src/protocol/Connection.h
+++ b/src/protocol/Connection.h
@@ -172,6 +172,10 @@ signals:
      * protocol version that both peers will accept. The socket will be closed.
      */
     void versionNegotiationFailed();
+    /* Hack to allow delivering an upgrade message to old clients
+     * XXX: Remove this once enough time has passed for most clients to be upgraded.
+     */
+    void oldVersionNegotiated(QTcpSocket *socket);
 
     void authenticated(AuthenticationType type, const QString &identity);
     void purposeChanged(Purpose after, Purpose before);

--- a/src/protocol/Connection_p.h
+++ b/src/protocol/Connection_p.h
@@ -47,6 +47,8 @@ class ConnectionPrivate : public QObject
     Q_DISABLE_COPY(ConnectionPrivate)
 
 public:
+    static const quint8 ProtocolVersion = 1;
+    static const quint8 ProtocolVersionFailed = 0xff;
     static const int PacketHeaderSize = 4;
     static const int PacketMaxDataSize = UINT16_MAX - PacketHeaderSize;
     // Time in seconds before a connection with a purpose of Unknown is killed
@@ -63,6 +65,7 @@ public:
     Connection::Direction direction;
     Connection::Purpose purpose;
     bool wasClosed;
+    bool handshakeDone;
 
     void setSocket(QTcpSocket *socket, Connection::Direction direction);
 

--- a/src/protocol/OutboundConnector.cpp
+++ b/src/protocol/OutboundConnector.cpp
@@ -264,7 +264,7 @@ void OutboundConnectorPrivate::onConnected()
             setError(QStringLiteral("Protocol version negotiation failed with peer"));
         }
     );
-
+    connect(connection, &Connection::oldVersionNegotiated, q, &OutboundConnector::oldVersionNegotiated);
     setStatus(OutboundConnector::Initializing);
 }
 

--- a/src/protocol/OutboundConnector.h
+++ b/src/protocol/OutboundConnector.h
@@ -95,6 +95,12 @@ signals:
     void statusChanged();
     void isActiveChanged();
 
+    /* Hack to allow sending an upgrade message to peers with old
+     * software versions that don't have a good way to handle this
+     * sort of situation.
+     */
+    void oldVersionNegotiated(QTcpSocket *socket);
+
 private:
     OutboundConnectorPrivate *d;
 };


### PR DESCRIPTION
Ricochet 1.0.x clients have no way of showing an error when they try to connect to clients running the newer protocol. We decided backwards compatibility would be too much extra work in this particular case, and it's still early enough to make a hard break without inconveniencing people too much.

This is an attempt to make that hard break less hard. When an _outbound_ connection is made to a known contact, and they negotiate the old protocol, it will send a chat message directing them to figure out how to upgrade:

![example](https://cloud.githubusercontent.com/assets/80188/6674630/a61f0d4a-cbe0-11e4-9572-bf2b2950adda.png)

That message is sent only once per contact, and only for outbound connections.

I don't like this solution, but since we currently lack a reliable way to tell users to upgrade, this seems like a step worth taking. Thoughts?