### PR TITLE
Remove the hidden service self-testing step

### DIFF
--- a/src/core/UserIdentity.cpp
+++ b/src/core/UserIdentity.cpp
@@ -173,11 +173,6 @@ bool UserIdentity::isServiceOnline() const
     return m_hiddenService && m_hiddenService->status() == Tor::HiddenService::Online;
 }
 
-bool UserIdentity::isServicePublished() const
-{
-    return m_hiddenService && m_hiddenService->status() >= Tor::HiddenService::Published;
-}
-
 #ifdef PROTOCOL_NEW
 /* Handle an incoming connection to this service
  *

--- a/src/core/UserIdentity.h
+++ b/src/core/UserIdentity.h
@@ -73,7 +73,6 @@ class UserIdentity : public QObject
     Q_PROPERTY(QString nickname READ nickname WRITE setNickname NOTIFY nicknameChanged)
     Q_PROPERTY(QString contactID READ contactID NOTIFY contactIDChanged)
     Q_PROPERTY(bool isOnline READ isServiceOnline NOTIFY statusChanged)
-    Q_PROPERTY(bool isPublished READ isServicePublished NOTIFY statusChanged)
     Q_PROPERTY(ContactsManager *contacts READ getContacts CONSTANT)
     Q_PROPERTY(SettingsObject *settings READ settings CONSTANT)
 
@@ -96,7 +95,6 @@ public:
 
     /* State */
     bool isServiceOnline() const;
-    bool isServicePublished() const;
     Tor::HiddenService *hiddenService() const { return m_hiddenService; }
 
     SettingsObject *settings();

--- a/src/tor/HiddenService.cpp
+++ b/src/tor/HiddenService.cpp
@@ -42,7 +42,7 @@
 using namespace Tor;
 
 HiddenService::HiddenService(const QString &p, QObject *parent)
-    : QObject(parent), dataPath(p), selfTest(0), pStatus(NotCreated)
+    : QObject(parent), dataPath(p), pStatus(NotCreated)
 {
     /* Set the initial status and, if possible, load the hostname */
     QDir dir(dataPath);
@@ -124,28 +124,6 @@ CryptoKey HiddenService::cryptoKey()
     return pCryptoKey;
 }
 
-void HiddenService::startSelfTest()
-{
-    if (pHostname.isEmpty() || pTargets.isEmpty())
-    {
-        if (selfTest)
-        {
-            delete selfTest;
-            selfTest = 0;
-        }
-
-        return;
-    }
-
-    if (!selfTest)
-    {
-        selfTest = new TorSocket(this);
-        connect(selfTest, SIGNAL(connected()), this, SLOT(selfTestSucceeded()));
-    }
-
-    selfTest->connectToHost(hostname(), pTargets[0].servicePort);
-}
-
 void HiddenService::servicePublished()
 {
     readHostname();
@@ -157,26 +135,6 @@ void HiddenService::servicePublished()
     }
 
     qDebug() << "Hidden service published successfully";
-    setStatus(Published);
-
-    startSelfTest();
-}
-
-void HiddenService::selfTestSucceeded()
-{
-    qDebug() << "Hidden service self-test completed successfully";
     setStatus(Online);
-
-    selfTest->deleteLater();
-    selfTest = 0;
-}
-
-void HiddenService::connectivityChanged()
-{
-    if (!torControl->hasConnectivity()) {
-        if (status() == Online)
-            setStatus(Published);
-        startSelfTest();
-    }
 }
 

--- a/src/tor/HiddenService.h
+++ b/src/tor/HiddenService.h
@@ -61,8 +61,7 @@ public:
     {
         NotCreated = -1, /* Service has not been created yet */
         Offline = 0, /* Data exists, but service is not published */
-        Published, /* Published, but not confirmed to be accessible */
-        Online /* Published and accessible */
+        Online /* Published */
     };
 
     const QString dataPath;
@@ -78,22 +77,16 @@ public:
     void addTarget(const Target &target);
     void addTarget(quint16 servicePort, QHostAddress targetAddress, quint16 targetPort);
 
-public slots:
-    void startSelfTest();
-
 signals:
     void statusChanged(int newStatus, int oldStatus);
     void serviceOnline();
 
 private slots:
     void servicePublished();
-    void selfTestSucceeded();
-    void connectivityChanged();
 
 private:
     QList<Target> pTargets;
     QString pHostname;
-    TorSocket *selfTest;
     Status pStatus;
     CryptoKey pCryptoKey;
 

--- a/src/ui/qml/TorPreferences.qml
+++ b/src/ui/qml/TorPreferences.qml
@@ -28,7 +28,7 @@ Item {
             Label { text: qsTr("Circuits established:") }
             Label { font.bold: true; text: ((torInstance.control.torStatus == TorControl.TorReady) ? qsTr("Yes") : qsTr("No")) }
             Label { text: qsTr("Hidden service:") }
-            Label { font.bold: true; text: (userIdentity.isOnline ? qsTr("Online") : (userIdentity.isPublished ? qsTr("Published") : qsTr("Offline"))) }
+            Label { font.bold: true; text: (userIdentity.isOnline ? qsTr("Online") : qsTr("Offline")) }
             Label { text: qsTr("Version:") }
             Label { font.bold: true; text: torControl.torVersion }
             //Label { text: "Recommended:" }


### PR DESCRIPTION
It's not necessary to self-test connectivity of the hidden service
immediately after we publish it. This information isn't used for
anything valuable, and in every observed situation, we already have a
good idea of whether our service is connectable or not based on tor's
circuit status.

It has also raised some concerns, because a new Ricochet client with no
contacts will start trying to connect to some scrubbed service in the
logs.

Fixes #26