### PR TITLE
Show old protocol version contacts as 'Outdated'

### DIFF
--- a/src/core/ContactUser.h
+++ b/src/core/ContactUser.h
@@ -89,7 +89,8 @@ public:
         Online,
         Offline,
         RequestPending,
-        RequestRejected
+        RequestRejected,
+        Outdated
     };
 
     UserIdentity * const identity;

--- a/src/ui/qml/ContactList.qml
+++ b/src/ui/qml/ContactList.qml
@@ -55,6 +55,7 @@ ScrollView {
                     case ContactUser.Offline: return qsTr("Offline")
                     case ContactUser.RequestPending: return qsTr("Requests")
                     case ContactUser.RequestRejected: return qsTr("Rejected")
+                    case ContactUser.Outdated: return qsTr("Outdated")
                 }
             }
             font.bold: true


### PR DESCRIPTION
This puts contacts that are known to be running the 1.0.x versions in an "Outdated" section, until they upgrade.

One concern is that this string isn't translated, and I doubt we could get many translations for it in time.