### PR TITLE
ui: Give a value to "always open in browser" always, if it isn't set.

### DIFF
--- a/src/ui/qml/GeneralPreferences.qml
+++ b/src/ui/qml/GeneralPreferences.qml
@@ -18,7 +18,7 @@ ColumnLayout {
 
     CheckBox {
         text: qsTr("Open links in default browser without prompting")
-        checked: uiSettings.data.alwaysOpenBrowser
+        checked: uiSettings.data.alwaysOpenBrowser || false
         onCheckedChanged: {
             uiSettings.write("alwaysOpenBrowser", checked)
         }


### PR DESCRIPTION
This mirrors the rest of the settings code, and fixes the following warning:
    qrc:/ui/GeneralPreferences.qml:21:18: Unable to assign [undefined] to bool