### PR TITLE
ui: Show a conversation separator if a sufficiently long timespan passes between messages.

### DIFF
--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -323,6 +323,7 @@ QHash<int,QByteArray> ConversationModel::roleNames() const
     roles[IsOutgoingRole] = "isOutgoing";
     roles[StatusRole] = "status";
     roles[SectionRole] = "section";
+    roles[TimespanRole] = "timespan";
     return roles;
 }
 
@@ -359,6 +360,12 @@ QVariant ConversationModel::data(const QModelIndex &index, int role) const
                     return QString();
             }
             return QStringLiteral("offline");
+        }
+        case TimespanRole: {
+            if (index.row() < messages.size() - 1)
+                return messages[index.row() + 1].time.secsTo(messages[index.row()].time);
+            else
+                return -1;
         }
     }
 

--- a/src/core/ConversationModel.h
+++ b/src/core/ConversationModel.h
@@ -60,7 +60,8 @@ public:
         TimestampRole = Qt::UserRole,
         IsOutgoingRole,
         StatusRole,
-        SectionRole
+        SectionRole,
+        TimespanRole
     };
 
     enum MessageStatus {

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -7,10 +7,26 @@ Column {
     width: parent.width
 
     Loader {
-        active: model.section === "offline"
+        active: {
+            if (model.section === "offline")
+                return true
+
+            // either this is the first message, or the message was a long time ago..
+            if ((model.timespan === -1 ||
+                 model.timespan > 3600 /* one hour */))
+                return true
+
+            return false
+        }
+
         sourceComponent: Label {
             //: %1 nickname
-            text: qsTr("%1 is offline").arg(contact !== null ? contact.nickname : "")
+            text: {
+                if (model.section === "offline")
+                    return qsTr("%1 is offline").arg(contact !== null ? contact.nickname : "")
+                else
+                    return Qt.formatDateTime(model.timestamp, Qt.DefaultLocaleShortDate)
+            }
             width: background.parent.width
             elide: Text.ElideRight
             horizontalAlignment: Qt.AlignHCenter


### PR DESCRIPTION
When talking with one person throughout multiple conversations over a long
period of time, it can become hard to get a sense of how much time has passed
since a message was received. To help with this, show a separator if a long time
has passed since the last message. For now, a democratically selected hour long
duration has been chosen.

Changes from Jan's original patch:

* Use blocks rather than writing large conditionals inline
* Use Qt's default date format (justification: if the date formatting looks
  "wrong" to someone, it is better that this problem be fixed within Qt, so that
  more places/software benefits)
* Use seconds instead of msec for timespan durations

Done-by: Jan Noertemann <jan.noertemann@uni-dortmund.de>