### PR TITLE
ui: Insert linebreak at cursor position on alt+enter

### DIFF
--- a/src/ui/qml/ChatPage.qml
+++ b/src/ui/qml/ChatPage.qml
@@ -131,8 +131,8 @@ FocusScope {
                     switch (event.key) {
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
-                            if (event.modifiers & Qt.ShiftModifier) {
-                                textInput.append("")
+                            if (event.modifiers & Qt.ShiftModifier || event.modifiers & Qt.AltModifier) {
+                                textInput.insert(textInput.cursorPosition, "\n")
                             } else {
                                 send()
                             }


### PR DESCRIPTION
This linebreak should be inserted at the cursor position, not always at
the end of the string. Also, allow alt+enter in addition to shift+enter
as a way to insert a linebreak.

Suggested by @RedLetterSec