### PR TITLE
doc: Update build dependency packages for Debian

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,9 +29,13 @@ yum install tor # or build your own
 #### Debian & Ubuntu
 ```sh
 apt-get install build-essential libssl-dev pkg-config libprotobuf-dev protobuf-compiler
-apt-get install qt5-qmake qt5-default qtbase5-dev qttools5-dev-tools qtdeclarative5-dev qtdeclarative5-controls-plugin
+apt-get install qt5-qmake qt5-default qtbase5-dev qttools5-dev-tools qtdeclarative5-dev
+apt-get install qml-module-qtquick-controls qml-module-qtquick-dialogs
 apt-get install tor # or build your own
 ```
+
+If the `qml-module-qtquick` packages aren't available, try `qtdeclarative5-controls-plugin` instead.
+
 #### Qt SDK
 The [Qt SDK](https://qt-project.org/downloads) is available for most Linux systems and includes an IDE as well as all Qt dependencies.
 


### PR DESCRIPTION
The qtdeclarative5-controls-plugin package looks to be Ubuntu-specific,
and even as of Ubuntu 14.10, it uses the new qml-module-qtquick form.

Fixes #173 and #174