### PR TITLE
ui: Show an error and exit if the root QML fails to load.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,6 +95,8 @@ int main(int argc, char *argv[])
 
     /* Window */
     MainWindow w;
+    if (!w.showUI())
+        return 1;
 
     return a.exec();
 }

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -83,7 +83,14 @@ MainWindow::MainWindow(QObject *parent)
     qmlRegisterSingletonType<LinkedText>("im.ricochet", 1, 0, "LinkedText", linkedtext_singleton);
 
     qRegisterMetaType<PendingOperation*>();
+}
 
+MainWindow::~MainWindow()
+{
+}
+
+bool MainWindow::showUI()
+{
     Q_ASSERT(!identityManager->identities().isEmpty());
     qml->rootContext()->setContextProperty(QLatin1String("userIdentity"), identityManager->identities()[0]);
     qml->rootContext()->setContextProperty(QLatin1String("torControl"), torControl);
@@ -91,10 +98,17 @@ MainWindow::MainWindow(QObject *parent)
     qml->rootContext()->setContextProperty(QLatin1String("uiMain"), this);
 
     qml->load(QUrl(QLatin1String("qrc:/ui/main.qml")));
-}
 
-MainWindow::~MainWindow()
-{
+    if (qml->rootObjects().isEmpty()) {
+        // Assume this is only applicable to technical users; not worth translating or simplifying.
+        QMessageBox::critical(0, QStringLiteral("Ricochet"),
+            QStringLiteral("An error occurred while loading the Ricochet UI.\n\n"
+                           "You might be missing plugins or dependency packages."));
+        qCritical() << "Failed to load UI. Exiting.";
+        return false;
+    }
+
+    return true;
 }
 
 QString MainWindow::version() const

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -57,6 +57,8 @@ public:
     explicit MainWindow(QObject *parent = 0);
     ~MainWindow();
 
+    bool showUI();
+
     QString aboutText() const;
     QString version() const;
     QVariantMap screens() const;


### PR DESCRIPTION
It doesn't seem worth translating and simplifying this error; it should
generally only apply for technical users with their own Qt.

Related to #174.