### PR TITLE
Fix SecureRNG return value and make RNG errors fatal

### DIFF
--- a/src/utils/SecureRNG.cpp
+++ b/src/utils/SecureRNG.cpp
@@ -93,26 +93,17 @@ bool SecureRNG::seed()
     return true;
 }
 
-bool SecureRNG::random(char *buf, int size)
+void SecureRNG::random(char *buf, int size)
 {
     int r = RAND_bytes(reinterpret_cast<unsigned char*>(buf), size);
     if (r <= 0)
-    {
-        qWarning() << "RNG failed:" << ERR_get_error();
-        return false;
-    }
-
-    return true;
+        qFatal("RNG failed: %lu", ERR_get_error());
 }
 
 QByteArray SecureRNG::random(int size)
 {
-    QByteArray re;
-    re.resize(size);
-
-    if (!random(re.data(), size))
-        return QByteArray();
-
+    QByteArray re(size, 0);
+    random(re.data(), size);
     return re;
 }
 

--- a/src/utils/SecureRNG.cpp
+++ b/src/utils/SecureRNG.cpp
@@ -109,9 +109,9 @@ QByteArray SecureRNG::random(int size)
 
 QByteArray SecureRNG::randomPrintable(int length)
 {
-    QByteArray re = random(length);
+    QByteArray re(length, 0);
     for (int i = 0; i < re.size(); i++)
-        re[i] = (quint8(re[i]) % 95) + 32;
+        re[i] = randomInt(95) + 32;
     return re;
 }
 

--- a/src/utils/SecureRNG.cpp
+++ b/src/utils/SecureRNG.cpp
@@ -96,7 +96,7 @@ bool SecureRNG::seed()
 bool SecureRNG::random(char *buf, int size)
 {
     int r = RAND_bytes(reinterpret_cast<unsigned char*>(buf), size);
-    if (!r)
+    if (r <= 0)
     {
         qWarning() << "RNG failed:" << ERR_get_error();
         return false;

--- a/src/utils/SecureRNG.h
+++ b/src/utils/SecureRNG.h
@@ -40,7 +40,7 @@ class SecureRNG
 public:
     static bool seed();
 
-    static bool random(char *buf, int size);
+    static void random(char *buf, int size);
     static QByteArray random(int size);
 
     static QByteArray randomPrintable(int length);


### PR DESCRIPTION
Fixes #164, and one of the suggestions from #89.