### PR TITLE
Fix leak of MessageDelegate context menu objects

### DIFF
--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -117,7 +117,8 @@ Column {
 
     function showContextMenu(link) {
         var object = contextMenu.createObject(delegate, (link !== undefined) ? { 'hoveredLink': link } : { })
-        object.visibleChanged.connect(function() { if (!object.visible) object.destroy() })
+        // XXX QtQuickControls private API. The only other option is 'visible', and it is not reliable. See PR#183
+        object.popupVisibleChanged.connect(function() { if (!object.__popupVisible) object.destroy() })
         object.popup()
     }
 


### PR DESCRIPTION
This needs a private API of QtQuickControls; I can't find a way to do it
with public API. The alternative is to move the menu instance outside of
MessageDelegate, and have a single instance of it always created for the
view.