### PR TITLE
Allow public keys up to 150 bytes (DER)

### DIFF
--- a/src/protocol/AuthHiddenServiceChannel.cpp
+++ b/src/protocol/AuthHiddenServiceChannel.cpp
@@ -194,7 +194,7 @@ void AuthHiddenServiceChannel::sendAuthMessage()
     }
 
     QByteArray publicKey = d->privateKey.encodedPublicKey(CryptoKey::DER);
-    if (publicKey.size() != 140) {
+    if (publicKey.size() > 150) {
         BUG() << "Unexpected size for encoded public key";
         closeChannel();
         return;
@@ -282,7 +282,7 @@ void AuthHiddenServiceChannel::handleProof(const Data::AuthHiddenService::Proof 
     CryptoKey publicKey;
     if (signature.size() != 128) {
         qWarning() << "Received invalid signature (size" << signature.size() << ") on" << type();
-    } else if (publicKeyData.size() > 180) {
+    } else if (publicKeyData.size() > 150) {
         qWarning() << "Received invalid public key (size" << publicKeyData.size() << ") on" << type();
     } else if (!publicKey.loadFromData(publicKeyData, CryptoKey::PublicKey, CryptoKey::DER)) {
         qWarning() << "Unable to parse public key from" << type();


### PR DESCRIPTION
~~Increases the limit on our local key to match validation for partner's key in an incoming connection~~

Sets the limit for both directions to 150 bytes to allow slightly unusual but still valid keys

Fixes #186