### PR TITLE
Adding an Away Status to Contacts #208

### DIFF
--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -347,6 +347,11 @@ void ContactUser::requestRemoved()
     }
 }
 
+void ContactUser::setAway() {
+    m_status = Away;
+    emit statusChanged();
+}
+
 void ContactUser::assignConnection(Protocol::Connection *connection)
 {
     if (connection == m_connection) {

--- a/src/core/ContactUser.h
+++ b/src/core/ContactUser.h
@@ -80,7 +80,8 @@ public:
         Offline,
         RequestPending,
         RequestRejected,
-        Outdated
+        Outdated,
+        Away
     };
 
     UserIdentity * const identity;
@@ -131,6 +132,7 @@ public slots:
     void setHostname(const QString &hostname);
 
     void updateStatus();
+    void setAway();
 
 signals:
     void statusChanged();

--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -277,14 +277,26 @@ QVariant ConversationModel::data(const QModelIndex &index, int role) const
     const MessageData &message = messages[index.row()];
 
     switch (role) {
-        case Qt::DisplayRole: return message.text;
+        case Qt::DisplayRole:
+            if(message.status == Received) {
+                if (message.text.startsWith(QLatin1String("/away"))) {
+                    m_contact->setAway();
+                } else if (message.text.startsWith(QLatin1String("/back"))) {
+                    m_contact->updateStatus();
+                }
+            }
+            return message.text;
         case TimestampRole: return message.time;
         case IsOutgoingRole: return message.status != Received;
         case StatusRole: return message.status;
 
         case SectionRole: {
-            if (m_contact->status() == ContactUser::Online)
+            if (m_contact->status() == ContactUser::Online) {
                 return QString();
+            }
+            if (m_contact->status() == ContactUser::Away) {
+                return QStringLiteral("away");
+            }
             if (index.row() < messages.size() - 1) {
                 const MessageData &next = messages[index.row()+1];
                 if (next.status != Received && next.status != Delivered)

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -24,6 +24,8 @@ Column {
             text: {
                 if (model.section === "offline")
                     return qsTr("%1 is offline").arg(contact !== null ? contact.nickname : "")
+                else if (model.section === "away")
+                    return qsTr("%1 is away").arg(contact !== null ? contact.nickname : "")
                 else
                     return Qt.formatDateTime(model.timestamp, Qt.DefaultLocaleShortDate)
             }
@@ -103,8 +105,20 @@ Column {
             wrapMode: TextEdit.Wrap
             readOnly: true
             selectByMouse: true
-            text: LinkedText.parsed(model.text)
-
+            text: {
+                  if(model.isOutgoing) {
+                      if(model.text === "/away")
+                        return qsTr("You are now <b>Away</b> to %1").arg(contact !== null ? contact.nickname : "");
+                      else if(model.text === "/back")
+                        return qsTr("You are now <b>Online</b> to %1").arg(contact !== null ? contact.nickname : "");
+                  } else {
+                      if(model.text === "/away")
+                        return qsTr("%1 is <b>away</b>").arg(contact !== null ? contact.nickname : "");
+                      else if(model.text === "/back")
+                        return qsTr("%1 has <b>returned</b>").arg(contact !== null ? contact.nickname : "");
+                  }
+                  return LinkedText.parsed(model.text)
+            }
             onLinkActivated: {
                 textField.deselect()
                 delegate.showContextMenu(link)

--- a/src/ui/qml/PresenceIcon.qml
+++ b/src/ui/qml/PresenceIcon.qml
@@ -12,6 +12,8 @@ Rectangle {
     onStatusChanged: {
         if (status === ContactUser.Online)
             color = "#3EBB4F"
+        else if (status === ContactUser.Away)
+            color = "#EEEE44"
         else
             color = "#999999"
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/106626/8631522/21f46378-272d-11e5-8ec0-4a1bc793bf39.png)

A small commit to add an away status which can be applied to each contact using the command "/away" and reset using "/back".

Currently the away status is on a per-user basis - this has some privacy benefits but may ultimately prove to be too messy - the next step in this space should be to add a global status (which can be implemented through the same mechanism described here.

I took some direction from https://github.com/ricochet-im/ricochet/pull/197 although tried not to spend to much time on changing the look and feel on the messages until a consensus is reached there.