### PR TITLE
Use custom scrolling instead of ScrollView

### DIFF
--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -54,7 +54,7 @@ Column {
         id: background
         width: Math.max(30, textField.width + 12)
         height: textField.height + 12
-        x: model.isOutgoing ? parent.width - width - 10 : 10
+        x: model.isOutgoing ? parent.width - width - 11 : 10
 
         property int __maxWidth: parent.width * 0.8
 


### PR DESCRIPTION
ScrollView is extremely buggy, and seems to regress in every Qt release.
It has a lot of trouble keeping the view scrolled to the bottom, and
with moving at a predictable rate in response to wheel events.

Writing a simple visual scrollbar and wheel handling manually makes for
a much better experience, even if we lose some platform-native scrollbar
behaviors.

---

This could use more testing on Qt <5.4, and on Windows or older Linux systems. It fixes a few Qt 5.5 regressions (#233).