### PR TITLE
Limit chat message length in UI

### DIFF
--- a/src/ui/qml/ChatPage.qml
+++ b/src/ui/qml/ChatPage.qml
@@ -144,8 +144,15 @@ FocusScope {
                 }
 
                 function send() {
+                    if (textInput.length > 2000)
+                        textInput.remove(2000, textInput.length)
                     conversationModel.sendMessage(textInput.text)
-                    textInput.text = ""
+                    textInput.remove(0, textInput.length)
+                }
+
+                onLengthChanged: {
+                    if (textInput.length > 2000)
+                        textInput.remove(2000, textInput.length)
                 }
             }
         }


### PR DESCRIPTION
This limit is applied by the protocol, so it should be apparent in UI as
well.

Also fixes a QTextCursor warning after sending messages, caused by
setting the text property instead of using remove().