### PR TITLE
Resolve problem #74

### DIFF
--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -79,7 +79,7 @@ QtObject {
         Connections {
             target: userIdentity.contacts.incomingRequests
             onRequestAdded: {
-                var object = createDialog("ContactRequestDialog.qml", { 'request': request }, mainWindow)
+                var object = createDialog("ContactRequestDialog.qml", { 'request': request })
                 object.visible = true
             }
         },
@@ -127,7 +127,7 @@ QtObject {
             onTriggered: {
                 var pendingRequests = userIdentity.contacts.incomingRequests.requests
                 for (var i = 0; i < pendingRequests.length; i++) {
-                    var object = createDialog("ContactRequestDialog.qml", { 'request': pendingRequests[i] }, mainWindow)
+                    var object = createDialog("ContactRequestDialog.qml", { 'request': pendingRequests[i] })
                     object.visible = true
                 }
             }


### PR DESCRIPTION
When contact request comes main.qml creates dialog without setting
parent window. It allow to open more contact requests dialogs even
if other dialogs are opened (including AddContactDialog).

I use KDE 4.14.2 and it works for me.