### PR TITLE
Add .travis-ci.yml for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+
+os:
+  - linux
+
+env:
+  - CONFIG=Debug
+  - CONFIG=Release
+
+install:
+  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-add-repository -y ppa:beineri/opt-qt541
+  - sudo apt-get -qq update
+  - sudo apt-get install -qq build-essential libssl-dev pkg-config
+  - sudo apt-get -qq install g++-4.8 libc6-i386 qt54tools qt54svg qt54multimedia qt54declarative qt54quick1 qt54quickcontrols qt54translations qt54imageformats 
+  - git clone https://github.com/google/protobuf.git
+  - cd protobuf
+  - git checkout v2.6.1
+  - ./autogen.sh
+  - ./configure
+  - make
+  - make check
+  - sudo make install
+  - cd ..
+  - sudo ldconfig
+  - export CXX="g++-4.8"
+  - export CC="gcc-4.8"
+  - sudo apt-get -f install
+  - sudo apt-get install -qq tor
+
+script:
+  - /opt/qt54/bin/qt54-env.sh 
+  - /opt/qt54/bin/qmake ricochet.pro CONFIG+=$CONFIG
+  - make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ricochet-im/ricochet.svg?branch=master)](https://travis-ci.org/ricochet-im/ricochet)
+
 ### Anonymous metadata-resistant instant messaging that just works
 Ricochet is an experiment with a different kind of instant messaging that **doesn't trust anyone** with your identity, your contact list, or your communications.
 


### PR DESCRIPTION
.travis.yml contains proper configuration of Travis-CI service
for Linux builds in Debug and Release configurations. README.md
has icon for with current building status. Icon indicates status
for https://github.com/ricochet-im/ricochet (branch master)
