### PR TITLE
Use QSharedPointer for Connection ownership

### DIFF
--- a/src/core/ContactUser.h
+++ b/src/core/ContactUser.h
@@ -37,7 +37,7 @@
 #include <QHash>
 #include <QMetaType>
 #include <QVariant>
-#include <QPointer>
+#include <QSharedPointer>
 #include "utils/Settings.h"
 #include "protocol/Connection.h"
 
@@ -89,7 +89,7 @@ public:
     explicit ContactUser(UserIdentity *identity, int uniqueID, QObject *parent = 0);
     virtual ~ContactUser();
 
-    Protocol::Connection *connection() { return m_connection.data(); }
+    const QSharedPointer<Protocol::Connection> &connection() { return m_connection; }
     bool isConnected() const { return status() == Online; }
 
     OutgoingContactRequest *contactRequest() { return m_contactRequest; }
@@ -126,7 +126,7 @@ public slots:
      * and reconnectng immediately - any ongoing operations will fail and need to
      * be retried at a higher level.
      */
-    void assignConnection(Protocol::Connection *connection);
+    void assignConnection(const QSharedPointer<Protocol::Connection> &connection);
 
     void setNickname(const QString &nickname);
     void setHostname(const QString &hostname);
@@ -137,7 +137,7 @@ signals:
     void statusChanged();
     void connected();
     void disconnected();
-    void connectionChanged(Protocol::Connection *connection);
+    void connectionChanged(const QWeakPointer<Protocol::Connection> &connection);
 
     void nicknameChanged();
     void contactDeleted(ContactUser *user);
@@ -150,7 +150,7 @@ private slots:
     void onSettingsModified(const QString &key, const QJsonValue &value);
 
 private:
-    QPointer<Protocol::Connection> m_connection;
+    QSharedPointer<Protocol::Connection> m_connection;
     Protocol::OutboundConnector *m_outgoingSocket;
 
     Status m_status;

--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -68,7 +68,7 @@ void ConversationModel::setContact(ContactUser *contact)
 
         auto connectConnection = [this,connectChannel]() {
             if (m_contact->connection()) {
-                connect(m_contact->connection(), &Protocol::Connection::channelOpened, this, connectChannel);
+                connect(m_contact->connection().data(), &Protocol::Connection::channelOpened, this, connectChannel);
                 foreach (auto channel, m_contact->connection()->findChannels<Protocol::ChatChannel>())
                     connectChannel(channel);
                 sendQueuedMessages();
@@ -95,7 +95,7 @@ void ConversationModel::sendMessage(const QString &text)
     if (m_contact->connection()) {
         auto channel = m_contact->connection()->findChannel<Protocol::ChatChannel>(Protocol::Channel::Outbound);
         if (!channel) {
-            channel = new Protocol::ChatChannel(Protocol::Channel::Outbound, m_contact->connection());
+            channel = new Protocol::ChatChannel(Protocol::Channel::Outbound, m_contact->connection().data());
             if (!channel->openChannel()) {
                 message.status = Error;
                 delete channel;
@@ -138,7 +138,7 @@ void ConversationModel::sendQueuedMessages()
 
     auto channel = m_contact->connection()->findChannel<Protocol::ChatChannel>(Protocol::Channel::Outbound);
     if (!channel) {
-        channel = new Protocol::ChatChannel(Protocol::Channel::Outbound, m_contact->connection());
+        channel = new Protocol::ChatChannel(Protocol::Channel::Outbound, m_contact->connection().data());
         if (!channel->openChannel()) {
             delete channel;
             return;

--- a/src/core/IncomingRequestManager.h
+++ b/src/core/IncomingRequestManager.h
@@ -97,7 +97,7 @@ signals:
     void hasActiveConnectionChanged();
 
 private:
-    QPointer<Protocol::Connection> connection;
+    QSharedPointer<Protocol::Connection> connection;
     QByteArray m_hostname;
     QByteArray m_remoteSecret;
     QString m_message, m_nickname;

--- a/src/core/OutgoingContactRequest.cpp
+++ b/src/core/OutgoingContactRequest.cpp
@@ -114,7 +114,7 @@ void OutgoingContactRequest::attemptAutoAccept()
     }
 }
 
-void OutgoingContactRequest::sendRequest(Protocol::Connection *connection)
+void OutgoingContactRequest::sendRequest(const QSharedPointer<Protocol::Connection> &connection)
 {
     if (connection != user->connection()) {
         BUG() << "OutgoingContactRequest connection doesn't match the assigned user";
@@ -127,7 +127,7 @@ void OutgoingContactRequest::sendRequest(Protocol::Connection *connection)
     }
 
     // XXX timeouts
-    Protocol::ContactRequestChannel *channel = new Protocol::ContactRequestChannel(Protocol::Channel::Outbound, connection);
+    Protocol::ContactRequestChannel *channel = new Protocol::ContactRequestChannel(Protocol::Channel::Outbound, connection.data());
     connect(channel, &Protocol::ContactRequestChannel::requestStatusChanged,
             this, &OutgoingContactRequest::requestStatusChanged);
 

--- a/src/core/OutgoingContactRequest.h
+++ b/src/core/OutgoingContactRequest.h
@@ -82,7 +82,7 @@ public slots:
     void reject(bool error = false, const QString &reason = QString());
     void cancel();
 
-    void sendRequest(Protocol::Connection *connection);
+    void sendRequest(const QSharedPointer<Protocol::Connection> &connection);
 
 signals:
     void statusChanged(int newStatus, int oldStatus);

--- a/src/core/UserIdentity.h
+++ b/src/core/UserIdentity.h
@@ -36,6 +36,8 @@
 #include "ContactsManager.h"
 #include <QObject>
 #include <QMetaType>
+#include <QVector>
+#include <QSharedPointer>
 
 namespace Tor
 {
@@ -95,6 +97,10 @@ public:
 
     SettingsObject *settings();
 
+    /* Take ownership of an inbound connection. Returns the shared pointer to
+     * the connection, and releases the reference held by UserIdentity. */
+    QSharedPointer<Protocol::Connection> takeIncomingConnection(Protocol::Connection *connection);
+
 signals:
     void statusChanged();
     void contactIDChanged(); // only possible during creation
@@ -111,6 +117,7 @@ private:
     SettingsObject *m_settings;
     Tor::HiddenService *m_hiddenService;
     QTcpServer *m_incomingServer;
+    QVector<QSharedPointer<Protocol::Connection>> m_incomingConnections;
 
     static UserIdentity *createIdentity(int uniqueID, const QString &dataDirectory = QString());
 

--- a/src/protocol/Connection.cpp
+++ b/src/protocol/Connection.cpp
@@ -40,8 +40,8 @@
 
 using namespace Protocol;
 
-Connection::Connection(QTcpSocket *socket, Direction direction, QObject *parent)
-    : QObject(parent)
+Connection::Connection(QTcpSocket *socket, Direction direction)
+    : QObject()
     , d(new ConnectionPrivate(this))
 {
     d->setSocket(socket, direction);
@@ -76,7 +76,9 @@ ConnectionPrivate::ConnectionPrivate(Connection *qq)
 
 Connection::~Connection()
 {
-    // When we call closeImemdiately, the list of channels will be cleared.
+    qDebug() << this << "Destroying connection";
+
+    // When we call closeImmediately, the list of channels will be cleared.
     // In the normal case, they will all use deleteLater to be freed at the
     // next event loop. Since the connection is being destructed immediately,
     // and we want to be certain that channels don't outlive it, copy the
@@ -227,10 +229,6 @@ void ConnectionPrivate::socketDisconnected()
         wasClosed = true;
         emit q->closed();
     }
-
-    // Ensure that we never leak Connection objects by scheduling deletion here.
-    // Everything should be using QPointer on a stored Connection for safety.
-    q->deleteLater();
 }
 
 void ConnectionPrivate::socketReadable()

--- a/src/protocol/Connection.h
+++ b/src/protocol/Connection.h
@@ -93,7 +93,7 @@ public:
      * becomes invalid (but is not automatically deleted) once
      * the socket has disconnected.
      */
-    explicit Connection(QTcpSocket *socket, Direction direction, QObject *parent);
+    explicit Connection(QTcpSocket *socket, Direction direction);
     virtual ~Connection();
 
     Direction direction() const;

--- a/src/protocol/OutboundConnector.h
+++ b/src/protocol/OutboundConnector.h
@@ -34,6 +34,7 @@
 #define PROTOCOL_OUTBOUNDCONNECTOR_H
 
 #include <QObject>
+#include <QSharedPointer>
 #include "Connection.h"
 #include "utils/CryptoKey.h"
 
@@ -80,12 +81,11 @@ public:
 
     /* Take ownership of the Connection object when Ready
      *
-     * This function is only valid in the Ready state. QObject
-     * ownership of the connection is passed to newParent, and
-     * the OutboundConnector is cleared and reset to the inactive
-     * state.
+     * This function is only valid in the Ready state.
+     * OutboundConnector will release ownership of the connection
+     * and reset to the inactive state.
      */
-    Connection *takeConnection(QObject *newParent);
+    QSharedPointer<Connection> takeConnection();
 
 public slots:
     void abort();


### PR DESCRIPTION
This makes the ownership of a Connection more clear, and removes a
lot of sketchy use of deleteLater to try to ensure connections are
always cleaned up at the right times.