### PR TITLE
Escaping HTML in Contact Users Nicknames

### DIFF
--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -289,7 +289,7 @@ QString ContactUser::nickname() const
 
 void ContactUser::setNickname(const QString &nickname)
 {
-    m_settings->write("nickname", nickname);
+    m_settings->write("nickname", nickname.toHtmlEscaped());
 }
 
 QString ContactUser::hostname() const


### PR DESCRIPTION
It turns out that if you enter html into a nickname it
doesn't get rendered during the initial contact request, but
if accepted, the html will render in the contacts column and
in the setting menu.

Mostly this isn't an issue (the odd style issue when users
set their nicks to be h1) however - it is possible, in the
limited 30 character space to construct an img tag which -
providing they can create a url short enough is enough to
automatically render the image and reveal the users IP
address to the server where the image is located.

This fix forces contact nick names to have html escaped.

![image](https://cloud.githubusercontent.com/assets/106626/10421693/ed903cb4-7061-11e5-8b8f-5b089bab1838.png)



