### PR TITLE
Updating URL Regex

### DIFF
--- a/src/ui/LinkedText.cpp
+++ b/src/ui/LinkedText.cpp
@@ -41,7 +41,7 @@ LinkedText::LinkedText(QObject *parent)
     : QObject(parent)
 {
     // Select things that look like URLs of some kind and allow QUrl::fromUserInput to validate them
-    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([^\\s,.);!>]|[,.);!>](?!\\s|$))+"), QRegularExpression::CaseInsensitiveOption);
+    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([\\p{L}\\p{N}\\-\\._~:=&/?#]+)"), QRegularExpression::CaseInsensitiveOption);
 
     allowedSchemes << QStringLiteral("http")
                    << QStringLiteral("https")


### PR DESCRIPTION
The old URL regex had a few issues which were revealed by fuzzing,
the biggest being that it accepted non-printable characters (e.g.
0x00 or 0x01) as part of the URL.

This created the scenario where a url of https://example.com/[0x00]
would be rendered as %2 (and attempting to open the link would give
a value like "https://example.com https://example.com " due to some
odd iteraction with the regex that I haven't quite worked out.

The new regex appears to work with all the iterations I have tried
and rejects non-printable characters.

Below are 2 picks, the first before the change with the old regex, and the second shot with the new regex.

The test strings were:

           ricochet.SendMessage("https://test.com/"+string(0x00)+"LOL", 5)
           ricochet.SendMessage("https://google.com", 5)
           ricochet.SendMessage("https://ع.com", 5)
           ricochet.SendMessage("https://عععععع<b>test</b>عععععععععع.com", 5)
           ricochet.SendMessage("https://عععععععععععععععع.com", 5)
           ricochet.SendMessage("https://ععع234233344ععععععععععععع.com/342?test=5&7=hello~", 5)

![before](https://cloud.githubusercontent.com/assets/106626/10446876/1a84050c-7134-11e5-814d-462c5591fa74.png)
![after](https://cloud.githubusercontent.com/assets/106626/10446878/24ed99ae-7134-11e5-80d8-47c6e02ccc0a.png)