### PR TITLE
Prevent bidi phishing

### DIFF
--- a/src/ui/LinkedText.cpp
+++ b/src/ui/LinkedText.cpp
@@ -41,7 +41,7 @@ LinkedText::LinkedText(QObject *parent)
     : QObject(parent)
 {
     // Select things that look like URLs of some kind and allow QUrl::fromUserInput to validate them
-    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([^\\s,.);!>]|[,.);!>](?!\\s|$))+"), QRegularExpression::CaseInsensitiveOption);
+    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([\\p{L}\\p{N}\\-\\._~:=&/?#]+)"), QRegularExpression::CaseInsensitiveOption);
 
     allowedSchemes << QStringLiteral("http")
                    << QStringLiteral("https")

--- a/src/ui/LinkedText.cpp
+++ b/src/ui/LinkedText.cpp
@@ -41,7 +41,7 @@ LinkedText::LinkedText(QObject *parent)
     : QObject(parent)
 {
     // Select things that look like URLs of some kind and allow QUrl::fromUserInput to validate them
-    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([\\p{L}\\p{N}\\-\\._~:=&/?#]+)"), QRegularExpression::CaseInsensitiveOption);
+    linkRegex = QRegularExpression(QStringLiteral("([a-z]{3,9}:|www\\.)([\\p{L}\\p{N}\\-\\._~:=&/%?#]+)"), QRegularExpression::CaseInsensitiveOption);
 
     allowedSchemes << QStringLiteral("http")
                    << QStringLiteral("https")
@@ -64,7 +64,11 @@ QString LinkedText::parsed(const QString &input)
 
         if (start > p)
             re.append(input.mid(p, start - p).toHtmlEscaped().replace(QLatin1Char('\n'), QStringLiteral("<br/>")));
-        re.append(QStringLiteral("<a href=\"%1\">%2</a>").arg(QString::fromLatin1(url.toEncoded()).toHtmlEscaped()).arg(match.capturedRef().toString().toHtmlEscaped()));
+        // Surround link with &#8234; (LEFT-TO-RIGHT EMBEDDING) and &#8236; (POP DIRECTIONAL FORMATTING ) 
+        // this will force URI's to be rendered left to right, while preserving the direction of the overall
+        // text. This prevents phising attacks where the attacker tries obscure the URI by using unicode
+        // bidi control characters. 
+        re.append(QStringLiteral("<a href=\"%1\">&#8234;%2&#8236;</a>").arg(QString::fromLatin1(url.toEncoded()).toHtmlEscaped()).arg(match.capturedRef().toString().toHtmlEscaped()));
         p = match.capturedEnd();
     }
 


### PR DESCRIPTION
Adding this is a separate PR, hence the duplicate url-regex commit.

Basically, this change is to prevent phishing attacks utilizing the unicode control characters to affect the rendering of the text so while the user sees https://ricochet.im the link actually goes to http://evil.com  - it's a fairly low level risk due to the fact a user has to add the person as a contact, and ultimately copy and paste the link etc. 
 
Sample of how the old code worked:
![csyhhcxwoaa6jld png large](https://cloud.githubusercontent.com/assets/106626/10779953/b9271616-7d2f-11e5-8f06-dc7f8507128f.png)

And the new code:

![screenshot - 102815 - 18 25 57](https://cloud.githubusercontent.com/assets/106626/10807925/405e5344-7ddd-11e5-9044-f0231f667135.png)

