### PR TITLE
Sanitize nicknames more carefully

### DIFF
--- a/src/protocol/ContactRequestChannel.cpp
+++ b/src/protocol/ContactRequestChannel.cpp
@@ -85,12 +85,17 @@ static bool isAcceptableNickname(const QString &input)
     if (input.size() > Data::ContactRequest::NicknameMaxCharacters)
         return false;
 
+    /* Although nicknames should always be escaped before being displayed
+     * in a HTML-sensitive context, there's little value in allowing these
+     * characters in nicknames, and it could prevent future bugs. */
+    QVector<uint> blacklist = QStringLiteral("\"<>&").toUcs4();
     QVector<uint> chars = input.toUcs4();
     foreach (uint value, chars) {
         QChar c(value);
         if (c.category() == QChar::Other_Format ||
             c.category() == QChar::Other_Control ||
-            c.isNonCharacter())
+            c.isNonCharacter() ||
+            blacklist.contains(value))
             return false;
     }
 

--- a/src/ui/qml/Bubble.qml
+++ b/src/ui/qml/Bubble.qml
@@ -19,6 +19,8 @@ Rectangle {
     opacity: displayed ? 1 : 0
     visible: opacity
 
+    property alias textFormat: label.textFormat
+
     property Item target
     property int maximumWidth: target ? target.width : 100
     property int horizontalAlignment: Qt.AlignHCenter
@@ -50,6 +52,7 @@ Rectangle {
         id: label
         wrapMode: Text.Wrap
         width: maximumWidth - 16
+        textFormat: Text.PlainText
         x: 6
         y: 6
     }

--- a/src/ui/qml/ChatPage.qml
+++ b/src/ui/qml/ChatPage.qml
@@ -45,6 +45,7 @@ FocusScope {
 
         Label {
             text: contact.nickname
+            textFormat: Text.PlainText
             font.pointSize: styleHelper.pointSize
         }
 
@@ -110,6 +111,7 @@ FocusScope {
                 Layout.maximumHeight: (styleHelper.textHeight * 4) + (2 * edit.textMargin)
                 textMargin: 3
                 wrapMode: TextEdit.Wrap
+                textFormat: TextEdit.PlainText
                 font.pointSize: styleHelper.pointSize
                 focus: true
 

--- a/src/ui/qml/ContactIDField.qml
+++ b/src/ui/qml/ContactIDField.qml
@@ -37,7 +37,7 @@ FocusScope {
                 onFailed: {
                     var contact
                     if ((contact = matchingContact(field.text)))
-                        errorBubble.show(qsTr("<b>%1</b> is already your contact").arg(contact.nickname))
+                        errorBubble.show(qsTr("<b>%1</b> is already your contact").arg(Utils.htmlEscaped(contact.nickname)))
                     else if (matchesIdentity(field.text))
                         errorBubble.show(qsTr("You can't add yourself as a contact"))
                     else
@@ -49,6 +49,7 @@ FocusScope {
                 id: errorBubble
                 target: field
                 horizontalAlignment: Qt.AlignLeft
+                textFormat: Text.RichText
 
                 function show(value) {
                     text = value

--- a/src/ui/qml/ContactList.qml
+++ b/src/ui/qml/ContactList.qml
@@ -65,6 +65,7 @@ ScrollView {
                 font.pointSize: styleHelper.pointSize
                 font.bold: true
                 font.capitalization: Font.SmallCaps
+                textFormat: Text.PlainText
                 color: "#3f454a"
 
                 text: {

--- a/src/ui/qml/ContactListDelegate.qml
+++ b/src/ui/qml/ContactListDelegate.qml
@@ -34,6 +34,7 @@ Rectangle {
             verticalCenter: parent.verticalCenter
         }
         text: model.name
+        textFormat: Text.PlainText
         elide: Text.ElideRight
         font.pointSize: styleHelper.pointSize
         color: "black"

--- a/src/ui/qml/ContactPreferences.qml
+++ b/src/ui/qml/ContactPreferences.qml
@@ -41,6 +41,7 @@ Item {
                 id: nickname
                 Layout.fillWidth: true
                 text: visible ? contactInfo.contact.nickname : ""
+                textFormat: Text.PlainText
                 horizontalAlignment: Qt.AlignHCenter
                 font.pointSize: styleHelper.pointSize + 1
 
@@ -99,6 +100,7 @@ Item {
                     Layout.fillWidth: true
                     elide: Text.ElideRight
                     text: visible ? Qt.formatDate(contactInfo.contact.settings.read("whenCreated"), Qt.DefaultLocaleLongDate) : ""
+                    textFormat: Text.PlainText
                 }
 
                 Label { text: qsTr("Last seen:"); visible: lastSeen.visible; Layout.alignment: Qt.AlignRight }
@@ -108,12 +110,14 @@ Item {
                     elide: Text.ElideRight
                     visible: contactInfo.request === null
                     text: visible ? Qt.formatDate(contactInfo.contact.settings.read("lastConnected"), Qt.DefaultLocaleLongDate) : ""
+                    textFormat: Text.PlainText
                 }
 
                 Label { text: qsTr("Request:"); visible: requestStatus.visible; Layout.alignment: Qt.AlignRight }
                 Label {
                     id: requestStatus
                     visible: contactInfo.request !== null
+                    textFormat: Text.PlainText
                     text: {
                         var re = ""
                         if (contactInfo.request === null)
@@ -139,6 +143,7 @@ Item {
                     Layout.fillWidth: true
                     elide: Text.ElideRight
                     text: visible ? contactInfo.request.rejectMessage : ""
+                    textFormat: Text.PlainText
                     visible: (contactInfo.request !== null) && (contactInfo.request.rejectMessage !== "")
                 }
             }

--- a/src/ui/qml/ContactRequestFields.qml
+++ b/src/ui/qml/ContactRequestFields.qml
@@ -45,6 +45,7 @@ GridLayout {
         id: messageField
         Layout.fillWidth: true
         Layout.fillHeight: true
+        textFormat: TextEdit.PlainText
         readOnly: contactFields.readOnly
     }
 }

--- a/src/ui/qml/MessageDelegate.qml
+++ b/src/ui/qml/MessageDelegate.qml
@@ -27,6 +27,7 @@ Column {
                 else
                     return Qt.formatDateTime(model.timestamp, Qt.DefaultLocaleShortDate)
             }
+            textFormat: Text.PlainText
             width: background.parent.width
             elide: Text.ElideRight
             horizontalAlignment: Qt.AlignHCenter

--- a/src/ui/qml/MessageDialogWrapper.qml
+++ b/src/ui/qml/MessageDialogWrapper.qml
@@ -1,12 +1,13 @@
 import QtQuick 2.0
 import QtQuick.Dialogs 1.1
+import "utils.js" as Utils
 
 MessageDialog {
     id: removeContactDialog
 
-    title: qsTr("Remove %1").arg(contact.nickname)
+    title: qsTr("Remove %1").arg(Utils.htmlEscaped(contact.nickname))
     //: %1 nickname
-    text: qsTr("Do you want to permanently remove %1?").arg(contact.nickname)
+    text: qsTr("Do you want to permanently remove %1?").arg(Utils.htmlEscaped(contact.nickname))
     informativeText: qsTr("This contact will no longer be able to message you, and will be notified about the removal. They may choose to send a new connection request.")
     standardButtons: StandardButton.Yes | StandardButton.No
     onYes: contact.deleteContact()

--- a/src/ui/qml/OpenBrowserDialog.qml
+++ b/src/ui/qml/OpenBrowserDialog.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.0
 import im.ricochet 1.0
+import "utils.js" as Utils
 
 ApplicationWindow {
     id: dialog
@@ -55,7 +56,7 @@ ApplicationWindow {
 
         CheckBox {
             id: alwaysOpenContact
-            text: qsTr("Don't ask again for links from %1").arg(contact ? contact.nickname : "???")
+            text: qsTr("Don't ask again for links from %1").arg(contact ? Utils.htmlEscaped(contact.nickname) : "???")
             checked: contact.settings.data.alwaysOpenBrowser || false
         }
 

--- a/src/ui/qml/TorBootstrapStatus.qml
+++ b/src/ui/qml/TorBootstrapStatus.qml
@@ -27,6 +27,7 @@ Column {
 
     Label {
         text: (bootstrap['warning'] !== undefined ) ? bootstrap['warning'] : bootstrap['summary']
+        textFormat: Text.PlainText
     }
 
     TorLogDisplay {

--- a/src/ui/qml/TorLogDisplay.qml
+++ b/src/ui/qml/TorLogDisplay.qml
@@ -6,6 +6,7 @@ TextArea {
     id: logDisplay
     readOnly: true
     text: torInstance.logMessages.join('\n')
+    textFormat: TextEdit.PlainText
     wrapMode: TextEdit.Wrap
 
     Connections {

--- a/src/ui/qml/TorPreferences.qml
+++ b/src/ui/qml/TorPreferences.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.0
 import im.ricochet 1.0
+import "utils.js" as Utils
 
 Item {
     anchors.fill: parent
@@ -30,7 +31,7 @@ Item {
             Label { text: qsTr("Hidden service:") }
             Label { font.bold: true; text: (userIdentity.isOnline ? qsTr("Online") : qsTr("Offline")) }
             Label { text: qsTr("Version:") }
-            Label { font.bold: true; text: torControl.torVersion }
+            Label { font.bold: true; text: torControl.torVersion; textFormat: Text.PlainText }
             //Label { text: "Recommended:" }
             //Label { font.bold: true; text: "Unknown" }
         }
@@ -56,7 +57,7 @@ Item {
 
         Label {
             //: %1 is error message
-            text: qsTr("Error: <b>%1</b>").arg(errorMessage)
+            text: qsTr("Error: <b>%1</b>").arg(Utils.htmlEscaped(errorMessage))
             visible: errorMessage != ""
 
             property string errorMessage: {

--- a/src/ui/qml/qml.qrc
+++ b/src/ui/qml/qml.qrc
@@ -35,6 +35,7 @@
         <file>GeneralPreferences.qml</file>
         <file>LanguagePreferences.qml</file>
         <file>AudioNotifications.qml</file>
+        <file>utils.js</file>
     </qresource>
     <qresource prefix="/text">
         <file>../../../LICENSE</file>

--- a/src/ui/qml/utils.js
+++ b/src/ui/qml/utils.js
@@ -1,0 +1,11 @@
+.pragma library
+
+function htmlEscaped(str) {
+    str = str.replace(/&/g, "&amp;");
+    str = str.replace(/</g, "&lt;");
+    str = str.replace(/>/g, "&gt;");
+    str = str.replace(/"/g, "&quot;");
+    str = str.replace(/'/g, "&apos;");
+    return str
+}
+


### PR DESCRIPTION
> QML makes the questionable decision of parsing all Text items as
rich text if they appear to like HTML. This HTML parser is, fortunately,
nothing like a browser - it supports only simple visual formatting.
Still, in the worst case it can trigger network requests.

> We were being too lax with sanitizing variables before display, if they
weren't directly from an external source. In one case, this could lead
to deanonymization if a user reviews and accepts a contact request
with a nickname containing an <img> tag.

These commits harden against this problem in three ways: by blocking any possible network requests, ensuring nicknames are sanitized every time they're displayed, and by blocking a few more characters in incoming contact requests.

Nicknames in Ricochet are always set by the local user, so this wasn't directly a vulnerability. However, inbound contact requests can suggest a nickname, which is displayed (safely) and used if the user accepts the request without changing it. If that request was accepted despite the nickname, it would be possible for a remote user to trigger network activity.