### PR TITLE
Clear internal socket state after failed connections

### DIFF
--- a/src/tor/TorSocket.cpp
+++ b/src/tor/TorSocket.cpp
@@ -143,6 +143,10 @@ void TorSocket::connectToHost(const QHostAddress &address, quint16 port, OpenMod
 
 void TorSocket::onFailed()
 {
+    // Make sure the internal connection to the SOCKS proxy is closed
+    // Otherwise reconnect attempts will fail (#295)
+    close();
+
     if (reconnectEnabled() && !m_connectTimer.isActive()) {
         m_connectAttempts++;
         m_connectTimer.start(reconnectInterval() * 1000);


### PR DESCRIPTION
On recent builds, Ricochet was failing to reconnect to contacts after a first failed attempt, because the connection to the SOCKS proxy was stuck in a failed state. Fix this by closing the TorSocket after a failure, making Qt reset the internal SOCKS connection.

Fixes #295