### PR TITLE
Limit nick length and whitespaces in ContactUser and UserIdentity

### DIFF
--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -288,7 +288,9 @@ QString ContactUser::nickname() const
 
 void ContactUser::setNickname(const QString &nickname)
 {
-    m_settings->write("nickname", nickname);
+    QString newNick = nickname.simplified();
+    newNick.truncate(24);
+    m_settings->write("nickname", newNick);
 }
 
 QString ContactUser::hostname() const

--- a/src/core/UserIdentity.cpp
+++ b/src/core/UserIdentity.cpp
@@ -128,7 +128,9 @@ QString UserIdentity::nickname() const
 
 void UserIdentity::setNickname(const QString &nick)
 {
-    m_settings->write("nickname", nick);
+    QString newNick = nick.simplified();
+    newNick.truncate(24);
+    m_settings->write("nickname", newNick);
 }
 
 void UserIdentity::onSettingsModified(const QString &key, const QJsonValue &value)


### PR DESCRIPTION
Fixes #337.

Max nick length of 24 was chosen arbitrarily.

It seemed necessary to make changes in both ContactUser.cpp and UserIdentity.cpp even though only the changes in ContactUser.cpp seemed to have any affect.

