### PR TITLE
Use Tor's ADD_ONION command when available

### DIFF
--- a/ricochet.pro
+++ b/ricochet.pro
@@ -144,6 +144,7 @@ SOURCES += src/main.cpp \
     src/tor/ProtocolInfoCommand.cpp \
     src/tor/AuthenticateCommand.cpp \
     src/tor/SetConfCommand.cpp \
+    src/tor/AddOnionCommand.cpp \
     src/utils/StringUtil.cpp \
     src/core/ContactsManager.cpp \
     src/core/ContactUser.cpp \
@@ -173,6 +174,7 @@ HEADERS += src/ui/MainWindow.h \
     src/tor/ProtocolInfoCommand.h \
     src/tor/AuthenticateCommand.h \
     src/tor/SetConfCommand.h \
+    src/tor/AddOnionCommand.h \
     src/utils/StringUtil.h \
     src/core/ContactsManager.h \
     src/core/ContactUser.h \

--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -159,7 +159,7 @@ void ContactUser::updateOutgoingSocket()
 
     if (!m_outgoingSocket) {
         m_outgoingSocket = new Protocol::OutboundConnector(this);
-        m_outgoingSocket->setAuthPrivateKey(identity->hiddenService()->cryptoKey());
+        m_outgoingSocket->setAuthPrivateKey(identity->hiddenService()->privateKey());
         connect(m_outgoingSocket, &Protocol::OutboundConnector::ready, this,
             [this]() {
                 assignConnection(m_outgoingSocket->takeConnection());

--- a/src/core/UserIdentity.h
+++ b/src/core/UserIdentity.h
@@ -122,6 +122,7 @@ private:
     static UserIdentity *createIdentity(int uniqueID, const QString &dataDirectory = QString());
 
     void handleIncomingAuthedConnection(Protocol::Connection *connection);
+    void setupService();
 };
 
 Q_DECLARE_METATYPE(UserIdentity*)

--- a/src/tor/AddOnionCommand.cpp
+++ b/src/tor/AddOnionCommand.cpp
@@ -1,0 +1,105 @@
+/* Ricochet - https://ricochet.im/
+ * Copyright (C) 2016, John Brooks <john.brooks@dereferenced.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ *    * Neither the names of the copyright owners nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "AddOnionCommand.h"
+#include "tor/HiddenService.h"
+#include "utils/CryptoKey.h"
+#include "utils/StringUtil.h"
+
+using namespace Tor;
+
+AddOnionCommand::AddOnionCommand(HiddenService *service)
+    : m_service(service)
+{
+    Q_ASSERT(m_service);
+}
+
+bool AddOnionCommand::isSuccessful() const
+{
+    return statusCode() == 250 && m_errorMessage.isEmpty();
+}
+
+QByteArray AddOnionCommand::build()
+{
+    QByteArray out("ADD_ONION");
+
+    if (m_service->privateKey().isLoaded()) {
+        out += " RSA1024:";
+        out += m_service->privateKey().encodedPrivateKey(CryptoKey::DER).toBase64();
+    } else {
+        out += " NEW:RSA1024";
+    }
+
+    foreach (const HiddenService::Target &target, m_service->targets()) {
+        out += " Port=";
+        out += QByteArray::number(target.servicePort);
+        out += ",";
+        out += target.targetAddress.toString().toLatin1();
+        out += ":";
+        out += QByteArray::number(target.targetPort);
+    }
+
+    out.append("\r\n");
+    return out;
+}
+
+void AddOnionCommand::onReply(int statusCode, const QByteArray &data)
+{
+    TorControlCommand::onReply(statusCode, data);
+    if (statusCode != 250) {
+        m_errorMessage = QString::fromLatin1(data);
+        return;
+    }
+
+    const QByteArray keyPrefix("PrivateKey=RSA1024:");
+    if (data.startsWith(keyPrefix)) {
+        QByteArray keyData(QByteArray::fromBase64(data.mid(keyPrefix.size())));
+        CryptoKey key;
+        if (!key.loadFromData(keyData, CryptoKey::PrivateKey, CryptoKey::DER)) {
+            m_errorMessage = QStringLiteral("Key decoding failed");
+            return;
+        }
+
+        m_service->setPrivateKey(key);
+    }
+}
+
+void AddOnionCommand::onFinished(int statusCode)
+{
+    TorControlCommand::onFinished(statusCode);
+    if (isSuccessful())
+        emit succeeded();
+    else
+        emit failed(statusCode);
+}
+
+

--- a/src/tor/AddOnionCommand.h
+++ b/src/tor/AddOnionCommand.h
@@ -1,0 +1,77 @@
+/* Ricochet - https://ricochet.im/
+ * Copyright (C) 2016, John Brooks <john.brooks@dereferenced.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ *    * Neither the names of the copyright owners nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ADDONIONCOMMAND_H
+#define ADDONIONCOMMAND_H
+
+#include "TorControlCommand.h"
+#include <QList>
+#include <QPair>
+#include <QVariant>
+
+namespace Tor
+{
+
+class HiddenService;
+
+class AddOnionCommand : public TorControlCommand
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(AddOnionCommand)
+
+    Q_PROPERTY(QString errorMessage READ errorMessage CONSTANT)
+    Q_PROPERTY(bool successful READ isSuccessful CONSTANT)
+
+public:
+    AddOnionCommand(HiddenService *service);
+
+    QByteArray build();
+
+    QString errorMessage() const { return m_errorMessage; }
+    bool isSuccessful() const;
+
+signals:
+    void succeeded();
+    void failed(int code);
+
+protected:
+    HiddenService *m_service;
+    QString m_errorMessage;
+
+    virtual void onReply(int statusCode, const QByteArray &data);
+    virtual void onFinished(int statusCode);
+};
+
+}
+
+#endif // ADDONIONCOMMAND_H
+

--- a/src/tor/HiddenService.h
+++ b/src/tor/HiddenService.h
@@ -64,34 +64,39 @@ public:
         Online /* Published */
     };
 
-    const QString dataPath;
-
+    HiddenService(QObject *parent = 0);
     HiddenService(const QString &dataPath, QObject *parent = 0);
+    HiddenService(const CryptoKey &privateKey, const QString &dataPath = QString(), QObject *parent = 0);
 
-    Status status() const { return pStatus; }
+    Status status() const { return m_status; }
 
-    const QString &hostname() const { return pHostname; }
-    CryptoKey cryptoKey();
+    const QString &hostname() const { return m_hostname; }
+    const QString &dataPath() const { return m_dataPath; }
 
-    const QList<Target> &targets() const { return pTargets; }
+    CryptoKey privateKey() { return m_privateKey; }
+    void setPrivateKey(const CryptoKey &privateKey);
+
+    const QList<Target> &targets() const { return m_targets; }
     void addTarget(const Target &target);
     void addTarget(quint16 servicePort, QHostAddress targetAddress, quint16 targetPort);
 
 signals:
     void statusChanged(int newStatus, int oldStatus);
     void serviceOnline();
+    void privateKeyChanged();
 
 private slots:
     void servicePublished();
 
 private:
-    QList<Target> pTargets;
-    QString pHostname;
-    Status pStatus;
-    CryptoKey pCryptoKey;
+    QString m_dataPath;
+    QList<Target> m_targets;
+    QString m_hostname;
+    Status m_status;
+    CryptoKey m_privateKey;
 
+    void loadPrivateKey();
     void setStatus(Status newStatus);
-    void readHostname();
 };
 
 }

--- a/src/tor/TorControl.cpp
+++ b/src/tor/TorControl.cpp
@@ -485,9 +485,9 @@ void TorControlPrivate::publishServices()
     for (QList<HiddenService*>::Iterator it = services.begin(); it != services.end(); ++it)
     {
         HiddenService *service = *it;
-        QDir dir(service->dataPath);
+        QDir dir(service->dataPath());
 
-        qDebug() << "torctrl: Configuring hidden service at" << service->dataPath;
+        qDebug() << "torctrl: Configuring hidden service at" << service->dataPath();
 
         torConfig.append(qMakePair(QByteArray("HiddenServiceDir"), dir.absolutePath().toLocal8Bit()));
 

--- a/src/tor/TorControl.cpp
+++ b/src/tor/TorControl.cpp
@@ -37,6 +37,7 @@
 #include "AuthenticateCommand.h"
 #include "SetConfCommand.h"
 #include "GetConfCommand.h"
+#include "AddOnionCommand.h"
 #include "utils/StringUtil.h"
 #include "utils/Settings.h"
 #include "utils/PendingOperation.h"
@@ -46,6 +47,7 @@
 #include <QQmlEngine>
 #include <QTimer>
 #include <QSaveFile>
+#include <QRegularExpression>
 #include <QDebug>
 
 Tor::TorControl *torControl = 0;
@@ -479,31 +481,52 @@ void TorControlPrivate::publishServices()
         return;
     }
 
-    SetConfCommand *command = new SetConfCommand;
-    QList<QPair<QByteArray,QByteArray> > torConfig;
+    if (q->torVersionAsNewAs(QStringLiteral("0.2.7"))) {
+        foreach (HiddenService *service, services) {
+            if (service->hostname().isEmpty())
+                qDebug() << "torctrl: Creating a new hidden service";
+            else
+                qDebug() << "torctrl: Publishing hidden service" << service->hostname();
+            AddOnionCommand *onionCommand = new AddOnionCommand(service);
+            QObject::connect(onionCommand, &AddOnionCommand::succeeded, service, &HiddenService::servicePublished);
+            socket->sendCommand(onionCommand, onionCommand->build());
+        }
+    } else {
+        qDebug() << "torctrl: Using legacy SETCONF hidden service configuration for tor" << torVersion;
+        SetConfCommand *command = new SetConfCommand;
+        QList<QPair<QByteArray,QByteArray> > torConfig;
 
-    for (QList<HiddenService*>::Iterator it = services.begin(); it != services.end(); ++it)
-    {
-        HiddenService *service = *it;
-        QDir dir(service->dataPath());
-
-        qDebug() << "torctrl: Configuring hidden service at" << service->dataPath();
-
-        torConfig.append(qMakePair(QByteArray("HiddenServiceDir"), dir.absolutePath().toLocal8Bit()));
-
-        const QList<HiddenService::Target> &targets = service->targets();
-        for (QList<HiddenService::Target>::ConstIterator tit = targets.begin(); tit != targets.end(); ++tit)
+        foreach (HiddenService *service, services)
         {
-            QString target = QString::fromLatin1("%1 %2:%3").arg(tit->servicePort)
-                             .arg(tit->targetAddress.toString())
-                             .arg(tit->targetPort);
-            torConfig.append(qMakePair(QByteArray("HiddenServicePort"), target.toLatin1()));
+            if (service->dataPath().isEmpty())
+                continue;
+
+            if (service->privateKey().isLoaded() && !QFile::exists(service->dataPath() + QStringLiteral("/private_key"))) {
+                // This case can happen if tor is downgraded after the profile is created
+                qWarning() << "Cannot publish ephemeral hidden services with this version of tor; skipping";
+                continue;
+            }
+
+            qDebug() << "torctrl: Configuring hidden service at" << service->dataPath();
+
+            QDir dir(service->dataPath());
+            torConfig.append(qMakePair(QByteArray("HiddenServiceDir"), dir.absolutePath().toLocal8Bit()));
+
+            const QList<HiddenService::Target> &targets = service->targets();
+            for (QList<HiddenService::Target>::ConstIterator tit = targets.begin(); tit != targets.end(); ++tit)
+            {
+                QString target = QString::fromLatin1("%1 %2:%3").arg(tit->servicePort)
+                                 .arg(tit->targetAddress.toString())
+                                 .arg(tit->targetPort);
+                torConfig.append(qMakePair(QByteArray("HiddenServicePort"), target.toLatin1()));
+            }
+
+            QObject::connect(command, &SetConfCommand::setConfSucceeded, service, &HiddenService::servicePublished);
         }
 
-        QObject::connect(command, &SetConfCommand::setConfSucceeded, service, &HiddenService::servicePublished);
+        if (!torConfig.isEmpty())
+            socket->sendCommand(command, command->build(torConfig));
     }
-
-    socket->sendCommand(command, command->build(torConfig));
 }
 
 void TorControl::shutdown()
@@ -684,6 +707,30 @@ void TorControl::takeOwnership()
     QVariantMap options;
     options[QStringLiteral("__OwningControllerProcess")] = QVariant();
     setConfiguration(options);
+}
+
+bool TorControl::torVersionAsNewAs(const QString &match) const
+{
+    QRegularExpression r(QStringLiteral("[.-]"));
+    QStringList split = torVersion().split(r);
+    QStringList matchSplit = match.split(r);
+
+    for (int i = 0; i < matchSplit.size(); i++) {
+        if (i >= split.size())
+            return false;
+        bool ok1 = false, ok2 = false;
+        int currentVal = split[i].toInt(&ok1);
+        int matchVal = matchSplit[i].toInt(&ok2);
+        if (!ok1 || !ok2)
+            return false;
+        if (currentVal > matchVal)
+            return true;
+        if (currentVal < matchVal)
+            return false;
+    }
+
+    // Versions are equal, up to the length of match
+    return true;
 }
 
 #include "TorControl.moc"

--- a/src/tor/TorControl.h
+++ b/src/tor/TorControl.h
@@ -83,6 +83,7 @@ public:
     Status status() const;
     TorStatus torStatus() const;
     QString torVersion() const;
+    bool torVersionAsNewAs(const QString &version) const;
     QString errorMessage() const;
 
     bool hasConnectivity() const;

--- a/src/utils/CryptoKey.h
+++ b/src/utils/CryptoKey.h
@@ -62,7 +62,8 @@ public:
     bool isPrivate() const;
 
     QByteArray publicKeyDigest() const;
-    QByteArray encodedPublicKey(KeyFormat format = PEM) const;
+    QByteArray encodedPublicKey(KeyFormat format) const;
+    QByteArray encodedPrivateKey(KeyFormat format) const;
     QString torServiceID() const;
     int bits() const;
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS += cryptokey
+SUBDIRS += tst_cryptokey

--- a/tests/tst_cryptokey/tst_cryptokey.cpp
+++ b/tests/tst_cryptokey/tst_cryptokey.cpp
@@ -41,6 +41,7 @@ private slots:
     void load();
     void publicKeyDigest();
     void encodedPublicKey();
+    void encodedPrivateKey();
     void torServiceID();
     void sign();
 };
@@ -137,17 +138,39 @@ void TestCryptoKey::encodedPublicKey()
 
     CryptoKey key2;
     QVERIFY(key2.loadFromData(pemEncoded, CryptoKey::PublicKey));
-    QCOMPARE(key.encodedPublicKey(), key2.encodedPublicKey());
+    QCOMPARE(key.encodedPublicKey(CryptoKey::PEM), key2.encodedPublicKey(CryptoKey::PEM));
     QCOMPARE(key.publicKeyDigest(), key2.publicKeyDigest());
 
     CryptoKey key3;
     QVERIFY(key3.loadFromData(derEncoded, CryptoKey::PublicKey, CryptoKey::DER));
-    QCOMPARE(key.encodedPublicKey(), key3.encodedPublicKey());
+    QCOMPARE(key.encodedPublicKey(CryptoKey::DER), key3.encodedPublicKey(CryptoKey::DER));
     QCOMPARE(key.publicKeyDigest(), key3.publicKeyDigest());
 
     // Doesn't contain a private key
     CryptoKey key4;
     QVERIFY(!key4.loadFromData(pemEncoded, CryptoKey::PrivateKey));
+}
+
+void TestCryptoKey::encodedPrivateKey()
+{
+    CryptoKey key;
+    QVERIFY(key.loadFromData(alice, CryptoKey::PrivateKey));
+
+    QByteArray pemEncoded = key.encodedPrivateKey(CryptoKey::PEM);
+    QVERIFY(pemEncoded.contains("BEGIN RSA PRIVATE KEY"));
+
+    QByteArray derEncoded = key.encodedPrivateKey(CryptoKey::DER);
+    QVERIFY(!derEncoded.isEmpty());
+
+    CryptoKey key2;
+    QVERIFY(key2.loadFromData(pemEncoded, CryptoKey::PrivateKey));
+    QCOMPARE(key.encodedPrivateKey(CryptoKey::PEM), key2.encodedPrivateKey(CryptoKey::PEM));
+    QCOMPARE(key.publicKeyDigest(), key2.publicKeyDigest());
+
+    CryptoKey key3;
+    QVERIFY(key3.loadFromData(derEncoded, CryptoKey::PrivateKey, CryptoKey::DER));
+    QCOMPARE(key.encodedPrivateKey(CryptoKey::DER), key3.encodedPrivateKey(CryptoKey::DER));
+    QCOMPARE(key.publicKeyDigest(), key3.publicKeyDigest());
 }
 
 void TestCryptoKey::torServiceID()

--- a/tests/tst_cryptokey/tst_cryptokey.pro
+++ b/tests/tst_cryptokey/tst_cryptokey.pro
@@ -4,7 +4,7 @@ SOURCES += tst_cryptokey.cpp \
     $${SRC}/utils/CryptoKey.cpp \
     $${SRC}/utils/SecureRNG.cpp
 
-unix:!macx {
+unix {
     !isEmpty(OPENSSLDIR) {
         INCLUDEPATH += $${OPENSSLDIR}/include
         LIBS += -L$${OPENSSLDIR}/lib -lcrypto


### PR DESCRIPTION
For Tor >= 0.2.7, start using the ADD_ONION control command instead of SETCONF to configure hidden services, and store the private keys in our configuration file instead of as separate files on the filesystem.

Older versions of Tor remain supported, and the behavior will not change. There is an edge case where a profile is created with a new version of Tor and later downgraded - this is not supported. Don't do that.

Existing profiles will copy their keys into the configuration and stop using the files on disk, but those files will not be removed yet to help avoid any risk of data loss. They will be removed later, likely when we enable profile encryption.

Fixes #227 