### PR TITLE
Allow configuring external Tor in the environment

### DIFF
--- a/src/tor/TorControl.h
+++ b/src/tor/TorControl.h
@@ -59,6 +59,7 @@ class TorControl : public QObject
     Q_PROPERTY(QString torVersion READ torVersion NOTIFY connected)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY statusChanged)
     Q_PROPERTY(QVariantMap bootstrapStatus READ bootstrapStatus NOTIFY bootstrapStatusChanged)
+    Q_PROPERTY(bool hasOwnership READ hasOwnership NOTIFY hasOwnershipChanged)
 
 public:
     enum Status
@@ -96,6 +97,10 @@ public:
     /* Connection */
     bool isConnected() const { return status() == Connected; }
     void connect(const QHostAddress &address, quint16 port);
+
+    /* Ownership means that tor is managed by this socket, and we
+     * can shut it down, own its configuration, etc. */
+    bool hasOwnership() const;
     void takeOwnership();
 
     /* Hidden Services */
@@ -114,6 +119,7 @@ signals:
     void disconnected();
     void connectivityChanged();
     void bootstrapStatusChanged();
+    void hasOwnershipChanged();
 
 public slots:
     /* Instruct Tor to shutdown */

--- a/src/ui/qml/TorConfigurationPage.qml
+++ b/src/ui/qml/TorConfigurationPage.qml
@@ -60,7 +60,8 @@ Column {
         var command = torControl.setConfiguration(conf)
         command.finished.connect(function() {
             if (command.successful) {
-                torControl.saveConfiguration()
+                if (torControl.hasOwnership)
+                    torControl.saveConfiguration()
                 window.openBootstrap()
             } else
                 console.log("SETCONF error:", command.errorMessage)

--- a/src/ui/qml/TorPreferences.qml
+++ b/src/ui/qml/TorPreferences.qml
@@ -74,6 +74,7 @@ Item {
 
         Button {
             text: qsTr("Configure")
+            visible: torControl.hasOwnership
             onClicked: {
                 var object = createDialog("NetworkSetupWizard.qml")
                 object.visible = true


### PR DESCRIPTION
```
    If the TOR_CONTROL_PORT environment variable is present, use that
    external instance of Tor instead of launching a bundled one.

    TOR_CONTROL_HOST and TOR_CONTROL_PASSWD are also available for the
    control hostname and password respectively. These variables match
    the names used by Tor Browser.

    There is no need to configure the SOCKS address; Ricochet will discover
    it automatically.
```

Also, avoid making destructive changes to a tor instance we didn't start, by tracking whether we've taken ownership or not.