### PR TITLE
Fix parsing of links containing escape sequences

### DIFF
--- a/src/ui/LinkedText.cpp
+++ b/src/ui/LinkedText.cpp
@@ -64,7 +64,7 @@ QString LinkedText::parsed(const QString &input)
 
         if (start > p)
             re.append(input.mid(p, start - p).toHtmlEscaped().replace(QLatin1Char('\n'), QStringLiteral("<br/>")));
-        re.append(QStringLiteral("<a href=\"%1\">%2</a>").arg(QString::fromLatin1(url.toEncoded()).toHtmlEscaped()).arg(match.capturedRef().toString().toHtmlEscaped()));
+        re.append(QStringLiteral("<a href=\"%1\">%2</a>").arg(QString::fromLatin1(url.toEncoded()).toHtmlEscaped(), match.capturedRef().toString().toHtmlEscaped()));
         p = match.capturedEnd();
     }
 


### PR DESCRIPTION
When formatting links to be displayed in messages, using repeated calls
to QString::arg() will interpret '%0' and similar in the URL as a
placeholder, resulting in the link not being properly formatted.

Depending on the value, this can either result in a broken URL when
copied to the clipboard (#403), or the URL being displayed with a label
of just '%2' (#372).

This cannot be used to mislabel links, and there is no printf-style
format vulnerability with QString::arg. There is no security impact.