### PR TITLE
add some osx caveats to BUILDING doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -82,6 +82,15 @@ Normally, configuration will be stored in a `config.ricochet` folder, in the sam
 
 The `packaging/osx/release_osx.sh` script demonstrates how to build a redistributable app bundle.
 
+Since the openssl header files were removed in El Capitan, have qmake use the openssl that comes with brew (see the OPENSSLDIR var below).
+
+Steps:
+```
+brew install protobuf qt5 tor
+/usr/local/opt/qt5/bin/qmake OPENSSLDIR=/usr/local/opt/openssl/ CONFIG+=debug
+make
+```
+
 ## Windows
 
 Building for Windows is difficult. The process and scripts used for release builds are documented in the [buildscripts repository](https://github.com/ricochet-im/buildscripts/tree/master/mingw).


### PR DESCRIPTION
Add caveat to get around openssl includes having been removed in El
Capitan.
Add some step by step instructions including explicitly using qt5 qmake
since brew qt5 is keg only due to potential qt4/5 conflicts.