### PR TITLE
Don't animate window resizes in network setup

### DIFF
--- a/src/ui/qml/NetworkSetupWizard.qml
+++ b/src/ui/qml/NetworkSetupWizard.qml
@@ -134,15 +134,6 @@ ApplicationWindow {
         }
     }
 
-    Behavior on height {
-        // This window animation causes bad graphical behavior on Windows with 5.4.1
-        enabled: Qt.platform.os !== "windows"
-        SmoothedAnimation {
-            easing.type: Easing.InOutQuad
-            velocity: 1500
-        }
-    }
-
     Action {
         shortcut: StandardKey.Close
         onTriggered: window.close()


### PR DESCRIPTION
These window animations seem to break a lot of platforms, and generally
just look bad on everything except OS X. We're better off without them.

Fixes #417