### PR TITLE
add support for OpenSSL 1.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,11 @@ int main(int argc, char *argv[])
     initTranslation();
 
     /* Initialize OpenSSL's allocator */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     CRYPTO_malloc_init();
+#else
+    OPENSSL_malloc_init();
+#endif
 
     /* Seed the OpenSSL RNG */
     if (!SecureRNG::seed())

--- a/src/utils/CryptoKey.cpp
+++ b/src/utils/CryptoKey.cpp
@@ -129,9 +129,13 @@ bool CryptoKey::loadFromFile(const QString &path, KeyType type, KeyFormat format
 
 bool CryptoKey::isPrivate() const
 {
-    const BIGNUM *p, *q;
-    RSA_get0_factors(d->key, &p, &q);
-    return isLoaded() && (p != 0);
+    if (!isLoaded()) {
+      return false;
+    } else {
+        const BIGNUM *p, *q;
+        RSA_get0_factors(d->key, &p, &q);
+        return (p != 0);
+    }
 }
 
 int CryptoKey::bits() const

--- a/src/utils/CryptoKey.cpp
+++ b/src/utils/CryptoKey.cpp
@@ -35,8 +35,18 @@
 #include "Useful.h"
 #include <QtDebug>
 #include <QFile>
+#include <openssl/bn.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
+{
+  *p = r->p;
+  *q = r->q;
+}
+#define RSA_bits(o) (BN_num_bits((o)->n))
+#endif
 
 void base32_encode(char *dest, unsigned destlen, const char *src, unsigned srclen);
 bool base32_decode(char *dest, unsigned destlen, const char *src, unsigned srclen);
@@ -119,12 +129,14 @@ bool CryptoKey::loadFromFile(const QString &path, KeyType type, KeyFormat format
 
 bool CryptoKey::isPrivate() const
 {
-    return isLoaded() && d->key->p != 0;
+    const BIGNUM *p, *q;
+    RSA_get0_factors(d->key, &p, &q);
+    return isLoaded() && !(BN_is_zero(p));
 }
 
 int CryptoKey::bits() const
 {
-    return isLoaded() ? BN_num_bits(d->key->n) : 0;
+    return isLoaded() ? RSA_bits(d->key) : 0;
 }
 
 QByteArray CryptoKey::publicKeyDigest() const

--- a/src/utils/CryptoKey.cpp
+++ b/src/utils/CryptoKey.cpp
@@ -131,7 +131,7 @@ bool CryptoKey::isPrivate() const
 {
     const BIGNUM *p, *q;
     RSA_get0_factors(d->key, &p, &q);
-    return isLoaded() && !(BN_is_zero(p));
+    return isLoaded() && (p != 0);
 }
 
 int CryptoKey::bits() const


### PR DESCRIPTION
OpenSSL 1.1 introduces some API changes (https://wiki.openssl.org/index.php/1.1_API_Changes) which affect building of Ricochet. This PR adds some extra code to enable compiling with both the old and the new API. *Please review carefully before merging!*