### PR TITLE
fixes bad links and a misspelling

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -67,7 +67,7 @@ To take full advantage of the sanitizer options, you may need to install `libasa
 
 You will need:
  * Xcode (for toolchain)
- * Qt 5 - preferably the [Qt SDK](https://qt-project.org/downloads)
+ * Qt 5 - preferably the [Qt SDK](https://www.qt.io/download/)
  * Protocol Buffers (libprotobuf, protoc) - `brew install protobuf`
 
 You can either load `ricochet.pro` in Qt Creator and build normally, or build command-line with:
@@ -97,7 +97,7 @@ Building for Windows is difficult. The process and scripts used for release buil
 
 For development builds, you will want:
  * Visual Studio C++ or MinGW
- * Qt 5 - preferably the [Qt SDK](https://qt-project.org/downloads)
+ * Qt 5 - preferably the [Qt SDK](https://www.qt.io/download/)
  * OpenSSL (including libs and headers)
  * Protocol Buffers >= 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ricochet is not affiliated with or endorsed by The Tor Project.
 For more information, you can [read about Tor](https://www.torproject.org/about/overview.html.en) and [learn about Ricochet's design](https://github.com/ricochet-im/ricochet/blob/master/doc/design.md) or [protocol](https://github.com/ricochet-im/ricochet/blob/master/doc/protocol.md) (or the [old protocol](https://github.com/ricochet-im/ricochet/blob/master/doc/deprecated/protocol-1.0.txt)). Everything is [open-source](https://github.com/ricochet-im/ricochet/blob/master/LICENSE) and open to contribution.
 
 ### Experimental
-This software is an experiment. It hasn't been audited or formally reviewed by anyone. Security and anonymity are difficult topics, and you should carefully evaluate your risks and exposure with any software. *Do not rely on Ricochet for your safety* unless you have more trust in my work than it deserves. That said, I believe it does more to try to protect your privacy than any similar software, and is the best chance you have of witholding your personal information.
+This software is an experiment. It hasn't been audited or formally reviewed by anyone. Security and anonymity are difficult topics, and you should carefully evaluate your risks and exposure with any software. *Do not rely on Ricochet for your safety* unless you have more trust in my work than it deserves. That said, I believe it does more to try to protect your privacy than any similar software, and is the best chance you have of withholding your personal information.
 
 ### Downloads
 


### PR DESCRIPTION
Fixes misspelling of "withholding" in the README. 

Separately, should the sentence "It hasn't been audited or formally reviewed by anyone" be edited considering there was [an audit](https://ricochet.im/files/ricochet-ncc-audit-2016-01.pdf) released earlier this year? 

PS. Keep up the good work! 