### PR TITLE
keep app running even if window closed [on OS X]

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,10 @@ int main(int argc, char *argv[])
     a.setWindowIcon(QIcon(QStringLiteral(":/icons/ricochet.svg")));
 #endif
 
+#if defined(Q_OS_MAC)
+    a.setQuitOnLastWindowClosed(false);
+#endif
+
     QScopedPointer<SettingsFile> settings(new SettingsFile);
     SettingsObject::setDefaultFile(settings.data());
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -10,7 +10,6 @@ QtObject {
     id: root
 
     property MainWindow mainWindow: MainWindow {
-        onVisibleChanged: if (!visible) Qt.quit()
     }
 
     function createDialog(component, properties, parent) {


### PR DESCRIPTION
The default behavior of native OS X apps is to leave the app running
even on closing the last remaining window. Since the
quitOnLastWindowClosed property of QApplication is true by default, we
can remove the line of code that explicitly quits the app on the main
window not being visible.

reference: #343