### PR TITLE
Use the QtQuick 2D renderer by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
        This will also ensure full PAX/Grsecurity protections. */
     qputenv("QV4_FORCE_INTERPRETER",  "1");
     qputenv("QT_ENABLE_REGEXP_JIT",   "0");
+    /* Use QtQuick 2D renderer by default; ignored if not available */
+    if (qEnvironmentVariableIsEmpty("QMLSCENE_DEVICE"))
+        qputenv("QMLSCENE_DEVICE", "softwarecontext");
 
     QApplication a(argc, argv);
     a.setApplicationVersion(QLatin1String("1.1.3"));


### PR DESCRIPTION
See #367

Seems like there is a silent fallback to the default renderer if 'softwarecontext' isn't available. I'm getting good results with this renderer on our platforms with 5.6.2.