### PR TITLE
Deploy linux input plugins and remove unneeded plugins

### DIFF
--- a/ricochet.pro
+++ b/ricochet.pro
@@ -133,6 +133,14 @@ win32 {
     LIBS += -luser32 -lgdi32 -ladvapi32
 }
 
+# Exclude unneeded plugins from static builds
+QTPLUGIN.playlistformats = -
+QTPLUGIN.imageformats = -
+QTPLUGIN.printsupport = -
+QTPLUGIN.mediaservice = -
+# Include Linux input plugins
+unix:!macx:QTPLUGIN.platforminputcontexts = composeplatforminputcontextplugin ibusplatforminputcontextplugin
+
 DEFINES += QT_NO_CAST_FROM_ASCII QT_NO_CAST_TO_ASCII
 
 SOURCES += src/main.cpp \

--- a/ricochet.pro
+++ b/ricochet.pro
@@ -138,7 +138,7 @@ QTPLUGIN.playlistformats = -
 QTPLUGIN.imageformats = -
 QTPLUGIN.printsupport = -
 QTPLUGIN.mediaservice = -
-# Include Linux input plugins
+# Include Linux input plugins, which are missing by default, to provide complex input support. See issue #60.
 unix:!macx:QTPLUGIN.platforminputcontexts = composeplatforminputcontextplugin ibusplatforminputcontextplugin
 
 DEFINES += QT_NO_CAST_FROM_ASCII QT_NO_CAST_TO_ASCII


### PR DESCRIPTION
For Linux, we need to include the ibus and compose input plugins for
some input methods to work (e.g. dead keys). See issue #60.

Also, we don't need playlists, mediaservice, imageformats, or printing.
Remove those plugins from static builds. Unfortunately, this doesn't
remove them from deployment with windeployqt or macdeployqt.