### PR TITLE
Limit conversation history to 1000 entries (#345)

### DIFF
--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -117,6 +117,7 @@ void ConversationModel::sendMessage(const QString &text)
     beginInsertRows(QModelIndex(), 0, 0);
     messages.prepend(message);
     endInsertRows();
+    prune();
 }
 
 void ConversationModel::sendQueuedMessages()
@@ -185,6 +186,7 @@ void ConversationModel::messageReceived(const QString &text, const QDateTime &ti
     MessageData message(text, time, id, Received);
     messages.insert(row, message);
     endInsertRows();
+    prune();
 
     m_unreadCount++;
     emit unreadCountChanged();
@@ -316,3 +318,13 @@ int ConversationModel::indexOfIdentifier(MessageId identifier, bool isOutgoing) 
     return -1;
 }
 
+void ConversationModel::prune()
+{
+    const int history_limit = 1000;
+    while(messages.size() > history_limit)
+    {
+        beginRemoveRows(QModelIndex(), messages.size()-1, messages.size()-1);
+        messages.removeLast();
+        endRemoveRows();
+    }
+}

--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -321,10 +321,12 @@ int ConversationModel::indexOfIdentifier(MessageId identifier, bool isOutgoing) 
 void ConversationModel::prune()
 {
     const int history_limit = 1000;
-    while(messages.size() > history_limit)
+    if(messages.size() > history_limit)
     {
-        beginRemoveRows(QModelIndex(), messages.size()-1, messages.size()-1);
-        messages.removeLast();
+        beginRemoveRows(QModelIndex(), history_limit, messages.size()-1);
+        while(messages.size() > history_limit) {
+            messages.removeLast();
+        }
         endRemoveRows();
     }
 }

--- a/src/core/ConversationModel.cpp
+++ b/src/core/ConversationModel.cpp
@@ -321,10 +321,9 @@ int ConversationModel::indexOfIdentifier(MessageId identifier, bool isOutgoing) 
 void ConversationModel::prune()
 {
     const int history_limit = 1000;
-    if(messages.size() > history_limit)
-    {
+    if (messages.size() > history_limit) {
         beginRemoveRows(QModelIndex(), history_limit, messages.size()-1);
-        while(messages.size() > history_limit) {
+        while (messages.size() > history_limit) {
             messages.removeLast();
         }
         endRemoveRows();

--- a/src/core/ConversationModel.h
+++ b/src/core/ConversationModel.h
@@ -111,6 +111,7 @@ private:
     int m_unreadCount;
 
     int indexOfIdentifier(MessageId identifier, bool isOutgoing) const;
+    void prune();
 };
 
 #endif


### PR DESCRIPTION
From issue #345:

@s-rah 
>Ricochet will store messages at any rate until ultimately running out of memory. Locally on my small system I can get up to ~1M messages before ricochet consistently crashes.

This patch prunes old messages in the chat window to a hardcoded limit.
