### PR TITLE
Avoid race condition (ricochet-im/ricochet#278)

### DIFF
--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -328,9 +328,6 @@ void ContactUser::deleteContact()
         qDebug() << "Cancelling request associated with contact to be deleted";
         m_contactRequest->cancel();
     }
-    if (m_contactRequest) {
-        m_contactRequest->deleteLater();
-    }
 
     emit contactDeleted(this);
 

--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -327,6 +327,8 @@ void ContactUser::deleteContact()
     if (m_contactRequest) {
         qDebug() << "Cancelling request associated with contact to be deleted";
         m_contactRequest->cancel();
+    }
+    if (m_contactRequest) {
         m_contactRequest->deleteLater();
     }
 

--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -328,6 +328,7 @@ void ContactUser::deleteContact()
         qDebug() << "Cancelling request associated with contact to be deleted";
         m_contactRequest->cancel();
     }
+    Q_ASSERT(!m_contactRequest);
 
     emit contactDeleted(this);
 


### PR DESCRIPTION
between ContactUser::deleteContact()
and ContactUser::requestRemoved()