### PR TITLE
Fix crash in ContactUser::deleteContact()

### DIFF
--- a/src/core/ContactUser.cpp
+++ b/src/core/ContactUser.cpp
@@ -327,8 +327,8 @@ void ContactUser::deleteContact()
     if (m_contactRequest) {
         qDebug() << "Cancelling request associated with contact to be deleted";
         m_contactRequest->cancel();
-        m_contactRequest->deleteLater();
     }
+    Q_ASSERT(!m_contactRequest);
 
     emit contactDeleted(this);
 


### PR DESCRIPTION
Issue: ricochet-im/ricochet#278
There was a race condition between ContactUser::deleteContact() and ContactUser::requestRemoved().
Thanks to @pokulo @rburchell 