### PR TITLE
Fix LibreSSL compatibility

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     initTranslation();
 
     /* Initialize OpenSSL's allocator */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined (LIBRESSL_VERSION_NUMBER)
     CRYPTO_malloc_init();
 #else
     OPENSSL_malloc_init();

--- a/src/utils/CryptoKey.cpp
+++ b/src/utils/CryptoKey.cpp
@@ -39,7 +39,7 @@
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined (LIBRESSL_VERSION_NUMBER)
 void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
 {
   *p = r->p;


### PR DESCRIPTION
This is just a quick fix, there might be more sophisticated ways to check for the availability of those functions without relying on version-specific ifdefs.

Also: __I do not know if the resulting codepath is safe__. Please review not just this diff, but the resulting codepath.