### PR TITLE
Don't say Ricochet hasn't been audited

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ricochet is not affiliated with or endorsed by The Tor Project.
 For more information, you can [read about Tor](https://www.torproject.org/about/overview.html.en) and [learn about Ricochet's design](https://github.com/ricochet-im/ricochet/blob/master/doc/design.md) or [protocol](https://github.com/ricochet-im/ricochet/blob/master/doc/protocol.md) (or the [old protocol](https://github.com/ricochet-im/ricochet/blob/master/doc/deprecated/protocol-1.0.txt)). Everything is [open-source](https://github.com/ricochet-im/ricochet/blob/master/LICENSE) and open to contribution.
 
 ### Experimental
-This software is an experiment. It hasn't been audited or formally reviewed by anyone. Security and anonymity are difficult topics, and you should carefully evaluate your risks and exposure with any software. *Do not rely on Ricochet for your safety* unless you have more trust in my work than it deserves. That said, I believe it does more to try to protect your privacy than any similar software, and is the best chance you have of withholding your personal information.
+This software is an experiment. Security and anonymity are difficult topics, and you should carefully evaluate your risks and exposure with any software. *Do not rely on Ricochet for your safety* unless you have more trust in my work than it deserves. That said, I believe it does more to try to protect your privacy than any similar software, and is the best chance you have of withholding your personal information.
 
 ### Downloads
 


### PR DESCRIPTION
It has now been over a year since the NCC Group audit:
* https://motherboard.vice.com/en_us/article/ricochet-encrypted-messenger-tackles-metadata-problem-head-on
* https://ricochet.im/files/ricochet-ncc-audit-2016-01.pdf