### PR TITLE
Disable minimization of Preferences window

### DIFF
--- a/src/ui/qml/PreferencesDialog.qml
+++ b/src/ui/qml/PreferencesDialog.qml
@@ -10,6 +10,7 @@ ApplicationWindow {
     height: 400
     minimumHeight: 400
     title: qsTr("Ricochet Preferences")
+    flags: Qt.Dialog
 
     signal closed
     onVisibleChanged: if (!visible) closed()


### PR DESCRIPTION
Implements https://github.com/ricochet-im/ricochet/issues/495#issuecomment-269391133. Resolves #495.

From the Qt5 Qt::WindowFlags [docs](http://doc.qt.io/qt-5/qt.html#WindowType-enum):

> `Qt::Dialog`: Indicates that the widget is a window that should be decorated as a dialog (i.e., typically no maximize or minimize buttons in the title bar).

On macOS, it looks like this:

![screen shot 2017-09-15 at 20 52 42](https://user-images.githubusercontent.com/407302/30508933-d7231fa6-9a57-11e7-91e5-697ee23195ef.png)