### PR TITLE
WIP create v3 onion service (Fixes #575)

### DIFF
--- a/src/tor/TorControl.cpp
+++ b/src/tor/TorControl.cpp
@@ -522,6 +522,8 @@ void TorControlPrivate::publishServices()
                                  .arg(tit->targetAddress.toString())
                                  .arg(tit->targetPort);
                 torConfig.append(qMakePair(QByteArray("HiddenServicePort"), target.toLatin1()));
+                QString version = QString::fromLatin1("3");
+                torConfig.append(qMakePair(QByteArray("HiddenServiceVersion"), version.toLatin1()));
             }
 
             QObject::connect(command, &SetConfCommand::setConfSucceeded, service, &HiddenService::servicePublished);


### PR DESCRIPTION
according to `config/tor/state` this commit has been tested with
TorVersion Tor 0.3.3.9 (git-ca1a436fa8e53a32)

In the UI the dialog to add contacts still shows a short id (ricochet:dkska2iuk3byot7g) and I expected it be longer, so maybe this change was not enough to create a v3 onion service yet.

I am waiting here for interested people to test if connections work (ricochet is not always on).