### PR TITLE
Fix typos and ensure odd-numbered channels have odd numbers

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -337,7 +337,7 @@ message ChatMessage {
 }
 ```
 
-A *message_id* of zero (or omitted) indicates that the recipient doesn't expect acknowledgement.
+A *message_id* of zero (or omitted) indicates that the sender doesn't expect acknowledgement.
 
 If *message_id* is non-zero, the recipient should acknowledge receiving this message by sending
 *ChatAcknowledge*. Unacknowledged messages may be re-sent with the same *message_id*, and the

--- a/src/protocol/Connection.cpp
+++ b/src/protocol/Connection.cpp
@@ -470,8 +470,7 @@ int ConnectionPrivate::availableOutboundChannelId()
     // Find an unused id, trying a maximum of 100 times, using a random step to avoid collision
     for (int i = 0; i < 100 && channels.contains(nextOutboundChannelId); i++) {
         nextOutboundChannelId += 1 + (qrand() % 200);
-        if (evenNumbered)
-            nextOutboundChannelId += nextOutboundChannelId % 2;
+        nextOutboundChannelId += (nextOutboundChannelId % 2) + (evenNumbered ? 0 : 1);
         if (nextOutboundChannelId > maxId)
             nextOutboundChannelId = minId;
     }

--- a/src/protocol/Connection.cpp
+++ b/src/protocol/Connection.cpp
@@ -459,7 +459,7 @@ bool ConnectionPrivate::writePacket(int channelId, const QByteArray &data)
 
 int ConnectionPrivate::availableOutboundChannelId()
 {
-    // Server opens even-nubmered channels, client opens odd-numbered
+    // Server opens even-numbered channels, client opens odd-numbered
     bool evenNumbered = (direction == Connection::ServerSide);
     const int minId = evenNumbered ? 2 : 1;
     const int maxId = evenNumbered ? (UINT16_MAX-1) : UINT16_MAX;


### PR DESCRIPTION
The logic in `availableOutboundChannelId` ensured that when a channel needs an even number, an even number is generated, but it did not ensure that when a channel needs an odd number, an odd number is generated.

It worked anyway, so probably the only time it ever needs an odd-numbered id, the number 1 would do, but it seems right to fix the logic anyway.