### PR TITLE
Adds missing item to "Steps" section in macOS build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,7 +87,7 @@ Since the openssl header files were removed in El Capitan, have qmake use the op
 
 Steps:
 ```
-brew install protobuf qt5 tor
+brew install protobuf qt5 tor pkg-config
 /usr/local/opt/qt5/bin/qmake OPENSSLDIR=/usr/local/opt/openssl/ CONFIG+=debug
 make
 ```


### PR DESCRIPTION
The build instructions for macOS provide a clear list of steps, but these steps are inconsistent with the more verbose instructions above: `pkg-config` is missing from the `brew install` command. 